### PR TITLE
Add project portfolio Codex skills

### DIFF
--- a/.codex/skills/ai-discovery-maintainer/SKILL.md
+++ b/.codex/skills/ai-discovery-maintainer/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: ai-discovery-maintainer
+description: AI-readable portfolio discovery maintenance for Waffy Ahmed's personalWebsite. Use when Codex updates or audits llms.txt, ai-summary.txt, portfolio.json, JSON-LD profile data, AI-agent guidance, structured project/case-study metadata, sitemap discovery links, or the way AI systems should summarize the portfolio.
+---
+
+# AI Discovery Maintainer
+
+## Workflow
+
+1. Preserve the intended AI summary: emphasize Waffy's backend, platform, production reliability, Kubernetes, observability, deployment automation, and incident-response work over website implementation details.
+2. Keep `main/public/llms.txt` short and navigational.
+3. Keep `main/public/ai-summary.txt` comprehensive, readable, and consistent with app content.
+4. Keep `main/public/portfolio.json` valid, structured, and stable for programmatic consumers.
+5. Keep JSON-LD in `main/index.html` aligned with canonical identity, resume, and case-study links.
+6. Run the static discovery check:
+
+```bash
+node .codex/skills/ai-discovery-maintainer/scripts/check_ai_discovery.mjs /path/to/personalWebsite
+```
+
+Read [references/ai-discovery-map.md](references/ai-discovery-map.md) before large AI-discovery edits.
+
+## Coordination
+
+If JSON-LD changes, also use `$csp-security-header-maintainer` because the inline script hash in `netlify.toml` may need to change.

--- a/.codex/skills/ai-discovery-maintainer/agents/openai.yaml
+++ b/.codex/skills/ai-discovery-maintainer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "AI Discovery Maintainer"
+  short_description: "Maintain AI-readable portfolio data"
+  default_prompt: "Use $ai-discovery-maintainer to refresh my portfolio AI-discovery files."

--- a/.codex/skills/ai-discovery-maintainer/references/ai-discovery-map.md
+++ b/.codex/skills/ai-discovery-maintainer/references/ai-discovery-map.md
@@ -1,0 +1,17 @@
+# AI Discovery Map
+
+## Files
+
+- `main/public/llms.txt`: short entry point for AI systems.
+- `main/public/ai-summary.txt`: long-form plain-text portfolio summary.
+- `main/public/portfolio.json`: structured data for tools.
+- `main/index.html`: JSON-LD profile graph and alternate links.
+- `main/public/sitemap.xml`: discoverable canonical URLs.
+
+## Summary Emphasis
+
+Emphasize backend/platform reliability over the website implementation. Strong topics include Kubernetes autoscaling, production operations, CI/CD modernization, observability, incident response, credential rotation, CVE remediation, Cassandra, Elasticsearch, BigQuery, Java, Python, and public health data reconciliation.
+
+## Coordination
+
+When case-study slugs, project IDs, resume links, social links, or site domain change, update all discovery files together.

--- a/.codex/skills/ai-discovery-maintainer/scripts/check_ai_discovery.mjs
+++ b/.codex/skills/ai-discovery-maintainer/scripts/check_ai_discovery.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+import fs from "node:fs"
+import path from "node:path"
+
+const repo = path.resolve(process.argv[2] ?? process.cwd())
+const errors = []
+
+const read = (rel) => fs.readFileSync(path.join(repo, rel), "utf8")
+const requireText = (label, text, value) => {
+  if (!text.includes(value)) errors.push(`${label} missing ${value}`)
+}
+
+let portfolio
+try {
+  portfolio = JSON.parse(read("main/public/portfolio.json"))
+} catch (error) {
+  errors.push(`portfolio.json is not valid JSON: ${error.message}`)
+}
+
+const llms = read("main/public/llms.txt")
+const aiSummary = read("main/public/ai-summary.txt")
+const indexHtml = read("main/index.html")
+const sitemap = read("main/public/sitemap.xml")
+
+if (portfolio) {
+  for (const key of ["site", "resume", "aiSummary", "llms"]) {
+    if (!portfolio.links?.[key]) errors.push(`portfolio.json missing links.${key}`)
+  }
+
+  for (const caseStudy of portfolio.caseStudies ?? []) {
+    requireText("llms.txt", llms, caseStudy.url)
+    requireText("sitemap.xml", sitemap, caseStudy.url)
+    requireText("index.html JSON-LD", indexHtml, caseStudy.url)
+  }
+
+  for (const topic of ["Kubernetes", "Observability", "Deployment automation"]) {
+    const hasTopic = JSON.stringify(portfolio).includes(topic) || aiSummary.includes(topic)
+    if (!hasTopic) errors.push(`AI discovery files missing topic ${topic}`)
+  }
+}
+
+for (const url of [
+  "https://waffy.netlify.app/ai-summary.txt",
+  "https://waffy.netlify.app/portfolio.json",
+  "https://waffy.netlify.app/sitemap.xml",
+  "https://waffy.netlify.app/waffyAhmedResume.pdf",
+]) {
+  requireText("llms.txt", llms, url)
+}
+
+for (const rel of ["/llms.txt", "/ai-summary.txt", "/portfolio.json"]) {
+  requireText("index.html alternates", indexHtml, rel)
+}
+
+if (errors.length > 0) {
+  console.error("AI discovery check failed:")
+  for (const error of errors) console.error(`- ${error}`)
+  process.exit(1)
+}
+
+console.log("AI discovery check passed")

--- a/.codex/skills/csp-security-header-maintainer/SKILL.md
+++ b/.codex/skills/csp-security-header-maintainer/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: csp-security-header-maintainer
+description: CSP and security-header maintenance for Waffy Ahmed's Netlify-hosted personalWebsite. Use when Codex changes inline JSON-LD, Google Analytics, Formspree, external assets, Netlify headers, Content-Security-Policy hashes, redirects, frame/object/base policies, or wants to verify that structured data is not blocked by security headers.
+---
+
+# CSP Security Header Maintainer
+
+## Workflow
+
+1. Inspect `netlify.toml` before changing any external script, form, image, frame, or connection behavior.
+2. If `main/index.html` JSON-LD changes, recompute the `script-src` SHA-256 hash.
+3. Keep the CSP narrow: allow only self, the inline JSON-LD hash, Google Tag Manager/Analytics, Formspree, data fonts/images when needed, and no object/frame embedding beyond current requirements.
+4. Run the CSP hash check:
+
+```bash
+node .codex/skills/csp-security-header-maintainer/scripts/check_csp_jsonld_hash.mjs /path/to/personalWebsite
+```
+
+Read [references/security-header-map.md](references/security-header-map.md) before changing headers.
+
+## Coordination
+
+Use this skill after `$ai-discovery-maintainer` when JSON-LD changes. Use a broader security scan only when the user asks for repository-wide security review.

--- a/.codex/skills/csp-security-header-maintainer/agents/openai.yaml
+++ b/.codex/skills/csp-security-header-maintainer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "CSP Security Header Maintainer"
+  short_description: "Maintain CSP and security headers"
+  default_prompt: "Use $csp-security-header-maintainer to update portfolio security headers safely."

--- a/.codex/skills/csp-security-header-maintainer/references/security-header-map.md
+++ b/.codex/skills/csp-security-header-maintainer/references/security-header-map.md
@@ -1,0 +1,18 @@
+# Security Header Map
+
+## Header Source
+
+- `netlify.toml` owns production headers.
+- The main CSP is attached to `/*`.
+- `main/index.html` contains inline JSON-LD with `id="portfolio-jsonld"`.
+
+## Current Allowances
+
+- Google Tag Manager and Google Analytics are allowed for GA4.
+- Formspree is allowed for contact form submission.
+- `data:` is allowed for images and fonts.
+- `object-src 'self'`, `base-uri 'self'`, and `frame-ancestors 'none'` should remain restrictive.
+
+## JSON-LD Hash
+
+The inline JSON-LD is allowed by a `script-src 'sha256-...'` token. Any byte-level change to that script text requires a new hash.

--- a/.codex/skills/csp-security-header-maintainer/scripts/check_csp_jsonld_hash.mjs
+++ b/.codex/skills/csp-security-header-maintainer/scripts/check_csp_jsonld_hash.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+import crypto from "node:crypto"
+import fs from "node:fs"
+import path from "node:path"
+
+const repo = path.resolve(process.argv[2] ?? process.cwd())
+const indexHtml = fs.readFileSync(path.join(repo, "main/index.html"), "utf8")
+const netlifyToml = fs.readFileSync(path.join(repo, "netlify.toml"), "utf8")
+
+const scriptMatch = indexHtml.match(
+  /<script id="portfolio-jsonld" type="application\/ld\+json">([\s\S]*?)<\/script>/
+)
+
+if (!scriptMatch) {
+  console.error("CSP hash check failed: missing portfolio-jsonld script in main/index.html")
+  process.exit(1)
+}
+
+const scriptText = scriptMatch[1]
+const expectedHash = `sha256-${crypto.createHash("sha256").update(scriptText).digest("base64")}`
+const hashTokens = [...netlifyToml.matchAll(/'sha256-([^']+)'/g)].map((match) => `sha256-${match[1]}`)
+
+if (!hashTokens.includes(expectedHash)) {
+  console.error("CSP JSON-LD hash mismatch")
+  console.error(`Expected token: '${expectedHash}'`)
+  if (hashTokens.length > 0) {
+    console.error(`Found tokens: ${hashTokens.map((hash) => `'${hash}'`).join(", ")}`)
+  } else {
+    console.error("Found tokens: none")
+  }
+  process.exit(1)
+}
+
+console.log(`CSP JSON-LD hash check passed: '${expectedHash}'`)

--- a/.codex/skills/ga4-portfolio-analytics/SKILL.md
+++ b/.codex/skills/ga4-portfolio-analytics/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: ga4-portfolio-analytics
+description: GA4 analytics maintenance for Waffy Ahmed's personalWebsite portfolio. Use when Codex adds, removes, audits, documents, tests, or debugs Google Analytics events for resume actions, project/source clicks, project details, case-study navigation, social links, contact form activity, page views, or GA4 key-event recommendations.
+---
+
+# GA4 Portfolio Analytics
+
+## Workflow
+
+1. Keep event emission in `main/src/utils/analytics.js`, `main/src/hooks/usePageTracking.jsx`, and the components that own the user action.
+2. Keep event tests in `main/src/App.test.jsx` close to the behavior being tracked.
+3. Keep recommended GA4 key events in `docs/analytics.md` and `main/public/portfolio.json`.
+4. Prefer these key-event candidates: `resume_download`, `contact_form_success`, `project_source_click`, and `case_study_link_click`.
+5. Run the event consistency check:
+
+```bash
+node .codex/skills/ga4-portfolio-analytics/scripts/check_ga4_events.mjs /path/to/personalWebsite
+```
+
+Read [references/ga4-event-map.md](references/ga4-event-map.md) before changing event names or parameters.
+
+## Rules
+
+Do not mark diagnostic events as conversion/key events by default. Keep event names lowercase with underscores, include useful `placement` values, and avoid sending empty params.

--- a/.codex/skills/ga4-portfolio-analytics/agents/openai.yaml
+++ b/.codex/skills/ga4-portfolio-analytics/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "GA4 Portfolio Analytics"
+  short_description: "Audit portfolio GA4 tracking"
+  default_prompt: "Use $ga4-portfolio-analytics to add or audit portfolio analytics events."

--- a/.codex/skills/ga4-portfolio-analytics/references/ga4-event-map.md
+++ b/.codex/skills/ga4-portfolio-analytics/references/ga4-event-map.md
@@ -1,0 +1,28 @@
+# GA4 Event Map
+
+## Event Sources
+
+- `main/src/utils/analytics.js`: GA initialization, event sending, link params.
+- `main/src/hooks/usePageTracking.jsx`: manual SPA page views.
+- `main/src/pages/Home.jsx`: home resume download.
+- `main/src/pages/Resume.jsx`: resume open/download.
+- `main/src/components/ProjectCard.jsx`: project source and details interactions.
+- `main/src/pages/CaseStudies.jsx` and `main/src/pages/CaseStudy.jsx`: case-study navigation.
+- `main/src/components/ContactForm.jsx`: contact submit and success.
+
+## Key-Event Candidates
+
+- `resume_download`
+- `contact_form_success`
+- `project_source_click`
+- `case_study_link_click`
+
+## Diagnostic Events
+
+- `page_view`
+- `resume_open`
+- `social_link_click`
+- `project_details_open`
+- `case_study_card_click`
+- `contact_form_submit`
+- `contact_email_click`

--- a/.codex/skills/ga4-portfolio-analytics/scripts/check_ga4_events.mjs
+++ b/.codex/skills/ga4-portfolio-analytics/scripts/check_ga4_events.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+import fs from "node:fs"
+import path from "node:path"
+
+const repo = path.resolve(process.argv[2] ?? process.cwd())
+const errors = []
+const warnings = []
+
+const read = (rel) => fs.readFileSync(path.join(repo, rel), "utf8")
+const walk = (dir) => {
+  const full = path.join(repo, dir)
+  return fs.readdirSync(full, { withFileTypes: true }).flatMap((entry) => {
+    const rel = path.join(dir, entry.name)
+    if (entry.isDirectory()) return walk(rel)
+    return entry.isFile() && /\.(jsx?|tsx?)$/.test(entry.name) ? [rel] : []
+  })
+}
+
+const srcTexts = walk("main/src").map((rel) => read(rel)).join("\n")
+const docs = read("docs/analytics.md")
+const readme = read("README.md")
+const tests = read("main/src/App.test.jsx")
+const portfolio = JSON.parse(read("main/public/portfolio.json"))
+
+const expectedEvents = [
+  "page_view",
+  "resume_open",
+  "resume_download",
+  "social_link_click",
+  "project_source_click",
+  "project_details_open",
+  "case_study_card_click",
+  "case_study_link_click",
+  "contact_form_submit",
+  "contact_form_success",
+  "contact_email_click",
+]
+
+const keyEventCandidates = [
+  "resume_download",
+  "contact_form_success",
+  "project_source_click",
+  "case_study_link_click",
+]
+
+for (const event of expectedEvents) {
+  if (!srcTexts.includes(`"${event}"`) && !srcTexts.includes(`'${event}'`)) {
+    warnings.push(`source does not currently emit ${event}`)
+  }
+  if (event === "page_view") {
+    if (!readme.includes(`\`${event}\``)) errors.push(`README.md missing ${event}`)
+  } else if (!docs.includes(`\`${event}\``)) {
+    errors.push(`docs/analytics.md missing ${event}`)
+  }
+}
+
+for (const event of keyEventCandidates) {
+  if (!portfolio.analyticsEvents?.keyEventCandidates?.includes(event)) {
+    errors.push(`portfolio.json keyEventCandidates missing ${event}`)
+  }
+}
+
+for (const event of ["page_view", "project_source_click", "resume_download", "contact_form_submit"]) {
+  if (!tests.includes(event)) warnings.push(`App.test.jsx does not assert ${event}`)
+}
+
+if (!srcTexts.includes("send_page_view: false")) {
+  errors.push("GA config should keep send_page_view false for manual SPA page views")
+}
+
+if (warnings.length > 0) {
+  console.warn("GA4 analytics warnings:")
+  for (const warning of warnings) console.warn(`- ${warning}`)
+}
+
+if (errors.length > 0) {
+  console.error("GA4 analytics check failed:")
+  for (const error of errors) console.error(`- ${error}`)
+  process.exit(1)
+}
+
+console.log("GA4 analytics check passed")

--- a/.codex/skills/portfolio-content-sync/SKILL.md
+++ b/.codex/skills/portfolio-content-sync/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: portfolio-content-sync
+description: Content synchronization for Waffy Ahmed's personalWebsite portfolio. Use when Codex updates profile, experience, projects, case studies, metrics, links, route slugs, public portfolio metadata, AI summaries, resume references, or recruiter-facing copy and needs to keep source data, public artifacts, SEO metadata, and discovery files aligned.
+---
+
+# Portfolio Content Sync
+
+## Workflow
+
+1. Treat `main/src/data/*` as the primary app content source.
+2. Update dependent public artifacts when content changes: `main/public/portfolio.json`, `main/public/ai-summary.txt`, `main/public/llms.txt`, `main/public/sitemap.xml`, and route metadata in `main/src/data/seo.js`.
+3. Preserve the portfolio voice: production ownership, measurable impact, reliability/platform focus, and precise technical claims.
+4. Avoid trust-risk copy. In particular, never imply Firestore stores user passwords; write that FirebaseAuth handles authentication and Firestore stores profile metadata, saved jobs, and preferences.
+5. Run the content sync check:
+
+```bash
+node .codex/skills/portfolio-content-sync/scripts/check_content_sync.mjs /path/to/personalWebsite
+```
+
+Read [references/content-map.md](references/content-map.md) before making broad content changes.
+
+## Editing Rules
+
+Keep public AI/SEO files consistent with visible portfolio content. If only wording changes, make the same meaning available in the structured JSON and AI-readable summary. If slugs or routes change, update App routes, route metadata, sitemap, llms, portfolio JSON, tests, and redirects together.

--- a/.codex/skills/portfolio-content-sync/agents/openai.yaml
+++ b/.codex/skills/portfolio-content-sync/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Portfolio Content Sync"
+  short_description: "Keep portfolio content aligned"
+  default_prompt: "Use $portfolio-content-sync to update my portfolio content consistently."

--- a/.codex/skills/portfolio-content-sync/references/content-map.md
+++ b/.codex/skills/portfolio-content-sync/references/content-map.md
@@ -1,0 +1,23 @@
+# Portfolio Content Map
+
+## Primary Content Files
+
+- `main/src/data/profile.js`: identity, intro, contact copy, social links, resume paths, deploy info.
+- `main/src/data/experience.js`: work, ownership, extracurricular experience.
+- `main/src/data/projects.js`: project cards and project stats.
+- `main/src/data/caseStudies.js`: case-study listing and detail pages.
+- `main/src/data/seo.js`: canonical route metadata and keywords.
+
+## Public Discovery Files
+
+- `main/public/portfolio.json`: structured public data for machines and AI systems.
+- `main/public/ai-summary.txt`: comprehensive plain-text portfolio summary.
+- `main/public/llms.txt`: concise AI-agent entry point.
+- `main/public/sitemap.xml`: canonical route discovery.
+
+## Copy Guardrails
+
+- Lead with reliability, platform ownership, Kubernetes, observability, deployment automation, incident response, and measurable impact.
+- Prefer precise metrics already supported by the repo.
+- Avoid wording that implies insecure credential storage. For Job Search Aid, say FirebaseAuth handled email/password authentication and Firestore stored profile metadata, saved jobs, and preferences.
+- Keep public-facing claims consistent across app data, JSON, AI summary, and README.

--- a/.codex/skills/portfolio-content-sync/scripts/check_content_sync.mjs
+++ b/.codex/skills/portfolio-content-sync/scripts/check_content_sync.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+import fs from "node:fs"
+import path from "node:path"
+
+const repo = path.resolve(process.argv[2] ?? process.cwd())
+const errors = []
+const warnings = []
+
+const read = (rel) => fs.readFileSync(path.join(repo, rel), "utf8")
+const exists = (rel) => fs.existsSync(path.join(repo, rel))
+const unique = (items) => [...new Set(items)]
+const extract = (text, regex) => unique([...text.matchAll(regex)].map((match) => match[1]))
+const requireFile = (rel) => {
+  if (!exists(rel)) errors.push(`Missing ${rel}`)
+}
+
+for (const rel of [
+  "main/src/data/profile.js",
+  "main/src/data/experience.js",
+  "main/src/data/projects.js",
+  "main/src/data/caseStudies.js",
+  "main/src/data/seo.js",
+  "main/public/portfolio.json",
+  "main/public/ai-summary.txt",
+  "main/public/llms.txt",
+  "main/public/sitemap.xml",
+]) {
+  requireFile(rel)
+}
+
+if (errors.length === 0) {
+  const projectsSource = read("main/src/data/projects.js")
+  const caseStudiesSource = read("main/src/data/caseStudies.js")
+  const seoSource = read("main/src/data/seo.js")
+  const portfolioText = read("main/public/portfolio.json")
+  const portfolio = JSON.parse(portfolioText)
+  const sitemap = read("main/public/sitemap.xml")
+  const aiSummary = read("main/public/ai-summary.txt")
+
+  const caseSlugs = extract(caseStudiesSource, /slug:\s*"([^"]+)"/g)
+  const projectsListSource = projectsSource.split("export const projects =")[1] ?? ""
+  const projectIds = extract(projectsListSource, /id:\s*"([^"]+)"/g)
+  const portfolioCaseSlugs = new Set((portfolio.caseStudies ?? []).map((item) => item.slug))
+  const portfolioProjectIds = new Set((portfolio.projects ?? []).map((item) => item.id))
+
+  for (const slug of caseSlugs) {
+    if (!portfolioCaseSlugs.has(slug)) errors.push(`portfolio.json missing case study slug ${slug}`)
+    if (!sitemap.includes(`/case-studies/${slug}`)) errors.push(`sitemap.xml missing /case-studies/${slug}`)
+    if (!seoSource.includes(`/case-studies/${slug}`) && !seoSource.includes("caseStudies.map")) {
+      errors.push(`seo.js does not appear to cover case-study slug ${slug}`)
+    }
+  }
+
+  for (const id of projectIds) {
+    if (!portfolioProjectIds.has(id)) errors.push(`portfolio.json missing project id ${id}`)
+  }
+
+  const riskyFirestorePasswordCopy = /Firestore[^.\n]*password|password[^.\n]*Firestore/i
+  for (const [label, text] of [
+    ["projects.js", projectsSource],
+    ["portfolio.json", portfolioText],
+    ["ai-summary.txt", aiSummary],
+  ]) {
+    if (riskyFirestorePasswordCopy.test(text)) {
+      warnings.push(`${label} may imply Firestore stores passwords; prefer FirebaseAuth plus Firestore profile metadata wording`)
+    }
+  }
+}
+
+if (warnings.length > 0) {
+  console.warn("Content sync warnings:")
+  for (const warning of warnings) console.warn(`- ${warning}`)
+}
+
+if (errors.length > 0) {
+  console.error("Content sync failed:")
+  for (const error of errors) console.error(`- ${error}`)
+  process.exit(1)
+}
+
+console.log("Content sync check passed")

--- a/.codex/skills/portfolio-release-qa/SKILL.md
+++ b/.codex/skills/portfolio-release-qa/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: portfolio-release-qa
+description: Portfolio release and pre-push QA for Waffy Ahmed's personalWebsite React/Vite portfolio. Use when Codex is asked to verify the site before push or deploy, install or update the pre-push checks, run lint/test/build, smoke-check core portfolio routes, validate resume/static assets, or review Netlify release readiness.
+---
+
+# Portfolio Release QA
+
+## Quick Start
+
+Resolve the repository root. The expected checkout contains `package.json`, `main/package.json`, `netlify.toml`, and `main/src`.
+
+Run the hook-safe checks:
+
+```bash
+bash .codex/skills/portfolio-release-qa/scripts/portfolio_preflight.sh /path/to/personalWebsite
+```
+
+Use this script for pre-push hooks because it only runs lint, tests, and production build. Keep preview servers and network smoke checks out of the hook unless the user explicitly asks for a slower hook.
+
+## Full Release Workflow
+
+1. Check `git status --short` and identify unrelated user changes before editing.
+2. Run `npm run lint`, `npm run test`, and `npm run build` from the repository root.
+3. For deploy readiness, run `npm run preview` and smoke-check `/`, `/resume`, `/projects`, `/case-studies`, `/experience`, `/contact`, `/waffyAhmedResume.pdf`, `/llms.txt`, `/ai-summary.txt`, and `/portfolio.json`.
+4. Inspect `netlify.toml` when headers, redirects, CSP, Formspree, GA4, or asset paths changed.
+5. Use [references/release-checklist.md](references/release-checklist.md) for expected routes, artifacts, and command notes.
+
+## Hook Policy
+
+Prefer a local `.git/hooks/pre-push` hook that calls a tracked repo script. Do not put long logic directly in the hook. The hook should fail fast on lint, tests, or build failures and print the command to bypass only when the user explicitly asks.

--- a/.codex/skills/portfolio-release-qa/agents/openai.yaml
+++ b/.codex/skills/portfolio-release-qa/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Portfolio Release QA"
+  short_description: "Run portfolio pre-release checks"
+  default_prompt: "Use $portfolio-release-qa to verify my portfolio before shipping."

--- a/.codex/skills/portfolio-release-qa/references/release-checklist.md
+++ b/.codex/skills/portfolio-release-qa/references/release-checklist.md
@@ -1,0 +1,22 @@
+# Portfolio Release Checklist
+
+## Fast Checks
+
+- Run from repository root: `npm run lint`, `npm run test`, `npm run build`.
+- Use `scripts/pre-push-checks.sh` as the repo hook target.
+- Keep hook-safe checks deterministic and offline.
+
+## Full Preview Checks
+
+- Start preview with `npm run preview`.
+- Smoke-check `/`, `/resume`, `/projects`, `/case-studies`, `/experience`, `/contact`, `/llms.txt`, `/ai-summary.txt`, `/portfolio.json`, and `/waffyAhmedResume.pdf`.
+- Confirm legacy uppercase routes redirect to lowercase canonical routes.
+- Confirm resume PDF is served and not replaced by the SPA shell.
+
+## Netlify Readiness
+
+- `netlify.toml` base: `main`.
+- Build command: `npm run build`.
+- Publish directory: `dist`.
+- Node version: `22`.
+- Check CSP when JSON-LD, GA4, Formspree, or asset hosts change.

--- a/.codex/skills/portfolio-release-qa/scripts/portfolio_preflight.sh
+++ b/.codex/skills/portfolio-release-qa/scripts/portfolio_preflight.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="${1:-$(pwd)}"
+
+cd "$repo_root"
+
+if [[ ! -f "package.json" || ! -f "main/package.json" ]]; then
+  echo "portfolio_preflight: expected personalWebsite repo root, got: $repo_root" >&2
+  exit 2
+fi
+
+echo "portfolio_preflight: running lint"
+npm run lint
+
+echo "portfolio_preflight: running tests"
+npm run test
+
+echo "portfolio_preflight: running production build"
+npm run build
+
+echo "portfolio_preflight: passed"

--- a/.codex/skills/resume-site-sync/SKILL.md
+++ b/.codex/skills/resume-site-sync/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: resume-site-sync
+description: Resume asset and portfolio-reference synchronization for Waffy Ahmed's personalWebsite. Use when Codex updates, replaces, previews, validates, links, opens, downloads, or summarizes the resume PDF; refreshes the resume preview image; checks resume route behavior; or keeps resume links in portfolio JSON, AI summary, llms.txt, redirects, and tests aligned.
+---
+
+# Resume Site Sync
+
+## Workflow
+
+1. Confirm the canonical PDF path is `main/public/waffyAhmedResume.pdf`.
+2. Confirm the preview image path is `main/public/resume-preview.png`.
+3. Keep `main/src/data/profile.js`, `main/src/pages/Resume.jsx`, `main/public/portfolio.json`, `main/public/llms.txt`, `main/public/ai-summary.txt`, and `main/public/_redirects` aligned with the canonical PDF.
+4. Use the existing `pdf:pdf` skill when resume visual rendering, text extraction, or PDF inspection matters.
+5. Run the resume asset check:
+
+```bash
+node .codex/skills/resume-site-sync/scripts/check_resume_assets.mjs /path/to/personalWebsite
+```
+
+Read [references/resume-map.md](references/resume-map.md) when replacing or regenerating resume assets.
+
+## Validation
+
+After changes, run the app test that covers `/resume`, then run build. For visual changes, render or inspect the resume preview on mobile and desktop widths before finishing.

--- a/.codex/skills/resume-site-sync/agents/openai.yaml
+++ b/.codex/skills/resume-site-sync/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Resume Site Sync"
+  short_description: "Sync resume assets and links"
+  default_prompt: "Use $resume-site-sync to update my resume assets and portfolio references."

--- a/.codex/skills/resume-site-sync/references/resume-map.md
+++ b/.codex/skills/resume-site-sync/references/resume-map.md
@@ -1,0 +1,20 @@
+# Resume Map
+
+## Canonical Assets
+
+- PDF: `main/public/waffyAhmedResume.pdf`
+- Preview image: `main/public/resume-preview.png`
+- Legacy redirect: `main/public/_redirects`
+
+## App References
+
+- `main/src/data/profile.js` defines `resume.pdf` and `resume.preview`.
+- `main/src/pages/Resume.jsx` owns open, download, and preview behavior.
+- `main/src/pages/Home.jsx` includes the homepage download action.
+- `main/src/App.test.jsx` verifies resume route behavior and analytics.
+
+## Public References
+
+- `main/public/portfolio.json` should expose the canonical absolute resume URL.
+- `main/public/llms.txt` should link the canonical resume PDF.
+- `main/public/ai-summary.txt` should summarize resume evidence when relevant.

--- a/.codex/skills/resume-site-sync/scripts/check_resume_assets.mjs
+++ b/.codex/skills/resume-site-sync/scripts/check_resume_assets.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+import fs from "node:fs"
+import path from "node:path"
+
+const repo = path.resolve(process.argv[2] ?? process.cwd())
+const errors = []
+
+const read = (rel) => fs.readFileSync(path.join(repo, rel), "utf8")
+const stat = (rel) => {
+  try {
+    return fs.statSync(path.join(repo, rel))
+  } catch {
+    errors.push(`Missing ${rel}`)
+    return null
+  }
+}
+
+const pdf = stat("main/public/waffyAhmedResume.pdf")
+const preview = stat("main/public/resume-preview.png")
+if (pdf && pdf.size === 0) errors.push("Resume PDF is empty")
+if (preview && preview.size === 0) errors.push("Resume preview image is empty")
+
+if (errors.length === 0) {
+  const profile = read("main/src/data/profile.js")
+  const resumePage = read("main/src/pages/Resume.jsx")
+  const redirects = read("main/public/_redirects")
+  const portfolio = JSON.parse(read("main/public/portfolio.json"))
+  const llms = read("main/public/llms.txt")
+
+  if (!profile.includes('pdf: "/waffyAhmedResume.pdf"')) errors.push("profile.js does not use canonical resume PDF path")
+  if (!profile.includes('preview: "/resume-preview.png"')) errors.push("profile.js does not use canonical resume preview path")
+  if (!resumePage.includes("resume.pdf") || !resumePage.includes("resume.preview")) {
+    errors.push("Resume.jsx should render from resume.pdf and resume.preview")
+  }
+  if (portfolio.links?.resume !== "https://waffy.netlify.app/waffyAhmedResume.pdf") {
+    errors.push("portfolio.json resume link is not canonical")
+  }
+  if (!llms.includes("https://waffy.netlify.app/waffyAhmedResume.pdf")) {
+    errors.push("llms.txt missing canonical resume PDF link")
+  }
+  if (!redirects.includes("/waffyahmedresume.pdf /waffyAhmedResume.pdf 301")) {
+    errors.push("_redirects missing legacy lowercase resume redirect")
+  }
+}
+
+if (errors.length > 0) {
+  console.error("Resume asset check failed:")
+  for (const error of errors) console.error(`- ${error}`)
+  process.exit(1)
+}
+
+console.log("Resume asset check passed")

--- a/.codex/skills/seo-spa-auditor/SKILL.md
+++ b/.codex/skills/seo-spa-auditor/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: seo-spa-auditor
+description: SEO and single-page-app route auditing for Waffy Ahmed's personalWebsite. Use when Codex changes route metadata, canonical URLs, sitemap entries, robots.txt, Open Graph or Twitter tags, route casing redirects, app routes, case-study slugs, prerender/static route strategy, or search/link-preview behavior for the React/Vite portfolio.
+---
+
+# SEO SPA Auditor
+
+## Workflow
+
+1. Confirm canonical route metadata in `main/src/data/seo.js`.
+2. Confirm React routes and legacy uppercase redirects in `main/src/App.jsx`.
+3. Confirm sitemap and robots discovery in `main/public/sitemap.xml` and `main/public/robots.txt`.
+4. Confirm static fallback metadata and alternate discovery links in `main/index.html`.
+5. Run the static SEO route check:
+
+```bash
+node .codex/skills/seo-spa-auditor/scripts/check_spa_seo.mjs /path/to/personalWebsite
+```
+
+Read [references/seo-map.md](references/seo-map.md) when routes, domains, or link-preview behavior change.
+
+## Runtime Checks
+
+For user-facing SEO work, build and preview the site, then inspect titles, descriptions, canonical URLs, and OG/Twitter tags after route navigation. SPA metadata updates after React loads, so distinguish browser-visible metadata from crawler-visible static HTML.

--- a/.codex/skills/seo-spa-auditor/agents/openai.yaml
+++ b/.codex/skills/seo-spa-auditor/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SEO SPA Auditor"
+  short_description: "Audit portfolio SPA SEO routes"
+  default_prompt: "Use $seo-spa-auditor to audit my portfolio SEO and route metadata."

--- a/.codex/skills/seo-spa-auditor/references/seo-map.md
+++ b/.codex/skills/seo-spa-auditor/references/seo-map.md
@@ -1,0 +1,24 @@
+# SEO SPA Map
+
+## Route Sources
+
+- `main/src/App.jsx`: React routes and legacy redirects.
+- `main/src/data/seo.js`: route titles, descriptions, canonical URL builder, sitemap route list.
+- `main/public/sitemap.xml`: public route discovery.
+- `main/index.html`: static fallback metadata, OG/Twitter defaults, alternate links.
+
+## High-Value Routes
+
+- `/`
+- `/case-studies`
+- `/case-studies/kubernetes-autoscaling`
+- `/case-studies/legacy-deployment-recovery`
+- `/case-studies/cdc-data-reconciliation`
+- `/experience`
+- `/projects`
+- `/resume`
+- `/contact`
+
+## SPA Caveat
+
+`Seo.jsx` updates metadata after React loads. Browser-visible metadata can be correct while crawler-visible static HTML remains generic. For important route previews, consider prerendering or static route shells before adding complex edge logic.

--- a/.codex/skills/seo-spa-auditor/scripts/check_spa_seo.mjs
+++ b/.codex/skills/seo-spa-auditor/scripts/check_spa_seo.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+import fs from "node:fs"
+import path from "node:path"
+
+const repo = path.resolve(process.argv[2] ?? process.cwd())
+const errors = []
+
+const read = (rel) => fs.readFileSync(path.join(repo, rel), "utf8")
+const unique = (items) => [...new Set(items)]
+const extract = (text, regex) => unique([...text.matchAll(regex)].map((match) => match[1]))
+
+const seo = read("main/src/data/seo.js")
+const app = read("main/src/App.jsx")
+const sitemap = read("main/public/sitemap.xml")
+const robots = read("main/public/robots.txt")
+const indexHtml = read("main/index.html")
+const caseStudies = read("main/src/data/caseStudies.js")
+
+const literalRoutes = extract(seo, /path:\s*"([^"]+)"/g).filter((route) => route !== "*")
+const caseStudyRoutes = extract(caseStudies, /slug:\s*"([^"]+)"/g).map((slug) => `/case-studies/${slug}`)
+const routes = unique([...literalRoutes, ...caseStudyRoutes])
+
+for (const route of routes) {
+  const url = route === "/" ? "https://waffy.netlify.app/" : `https://waffy.netlify.app${route}`
+  if (!sitemap.includes(`<loc>${url}</loc>`)) errors.push(`sitemap.xml missing ${url}`)
+}
+
+for (const route of ["/resume", "/contact", "/case-studies", "/experience", "/projects"]) {
+  if (!app.includes(`path="${route}"`)) errors.push(`App.jsx missing route ${route}`)
+}
+
+for (const legacy of ["/Resume", "/Contact", "/CaseStudies", "/Case-Studies", "/Experience", "/Projects"]) {
+  if (!app.includes(`path="${legacy}"`)) errors.push(`App.jsx missing legacy redirect ${legacy}`)
+}
+
+for (const required of [
+  'rel="canonical"',
+  'property="og:title"',
+  'property="og:description"',
+  'property="og:image"',
+  'name="twitter:card"',
+  'href="/sitemap.xml"',
+  'href="/llms.txt"',
+  'href="/ai-summary.txt"',
+  'href="/portfolio.json"',
+]) {
+  if (!indexHtml.includes(required)) errors.push(`index.html missing ${required}`)
+}
+
+if (!robots.includes("Sitemap: https://waffy.netlify.app/sitemap.xml")) {
+  errors.push("robots.txt missing canonical sitemap pointer")
+}
+
+if (errors.length > 0) {
+  console.error("SPA SEO check failed:")
+  for (const error of errors) console.error(`- ${error}`)
+  process.exit(1)
+}
+
+console.log("SPA SEO check passed")

--- a/scripts/pre-push-checks.sh
+++ b/scripts/pre-push-checks.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cd "$repo_root"
+
+echo "pre-push: running lint"
+npm run lint
+
+echo "pre-push: running tests"
+npm run test
+
+echo "pre-push: running production build"
+npm run build
+
+echo "pre-push: checks passed"


### PR DESCRIPTION
## Summary

- Add project-local Codex skills under `.codex/skills` for portfolio release QA, content sync, resume sync, AI discovery, SPA SEO, GA4 analytics, and CSP header maintenance.
- Add reusable skill scripts for consistency checks across portfolio content, resume assets, AI discovery files, SEO routes, GA4 events, CSP JSON-LD hashes, and release preflight.
- Add `scripts/pre-push-checks.sh` so the local pre-push hook has a tracked lint/test/build target.

## Validation

- Validated all 7 project-local skills with `quick_validate.py`.
- Ran project-local skill scripts for content, resume, AI discovery, SEO, GA4, and CSP checks.
- Ran `bash .codex/skills/portfolio-release-qa/scripts/portfolio_preflight.sh .`.
- Push preflight hook passed: lint, 17 tests, production build.

## Notes

- `docs/portfolio-feedback-roadmap.md` remains untracked and was not included in this PR.
- The content sync script currently emits a non-blocking warning about Job Search Aid Firestore/password wording so that known copy issue stays visible.