### PR TITLE
Add Codex agent guidance and PR publisher skill

### DIFF
--- a/.codex/skills/git-pr-publisher/SKILL.md
+++ b/.codex/skills/git-pr-publisher/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: git-pr-publisher
+description: Publish local repository changes as a focused GitHub pull request. Use when Codex is asked to stage files, commit changes, push the current or dev branch, create or update a PR against main, prepare PR title/body text, or safely ship local changes after implementation.
+---
+
+# Git PR Publisher
+
+## Overview
+
+Publish a local branch to GitHub with a reviewable commit and pull request. Optimize for preserving user-owned work, staging only intended files, verifying the branch before publishing, and creating a clear PR against `main`.
+
+## Workflow
+
+1. Inspect the worktree before changing Git state.
+   - Run `git status --short` and identify modified, deleted, and untracked files.
+   - Run `git branch --show-current` and confirm the current branch is not `main`.
+   - Treat unrelated user changes as out of scope. Do not revert them.
+   - If the current branch is `main`, stop and ask whether to create or switch to a feature/dev branch.
+
+2. Review the intended diff.
+   - Use `git diff --stat` and targeted `git diff -- <path>` for changed tracked files.
+   - Inspect untracked files before staging them.
+   - If the user did not explicitly define the scope and the worktree contains unrelated changes, summarize the candidate files and ask before staging.
+
+3. Verify before committing.
+   - Follow repository instructions such as `AGENTS.md` and any task-specific skill checks.
+   - For this portfolio repository, use `$portfolio-release-qa` for release, push, or deploy readiness.
+   - For docs-only or instruction-only changes, note why lint/tests/build were not necessary.
+   - If relevant checks fail, fix only failures clearly caused by the current change. Otherwise report the failure and stop before pushing unless the user explicitly asks to continue.
+
+4. Stage deliberately.
+   - Stage specific files with `git add -- <path> ...`.
+   - Avoid `git add .` unless the user explicitly requests all current changes and the diff has been reviewed.
+   - After staging, run `git diff --staged --stat` and inspect the staged diff enough to confirm it matches the intended scope.
+   - If nothing is staged, stop and tell the user there is nothing to commit.
+
+5. Commit clearly.
+   - Use a concise imperative commit message that describes the change.
+   - Prefer a single focused commit for one coherent change. Split commits only when the staged work contains logically separate changes.
+   - Do not amend, rebase, reset, or force-push unless the user explicitly asks.
+
+6. Push the branch.
+   - Use the current branch name as the head branch.
+   - If no upstream is set, push with `git push -u origin <branch>`.
+   - If an upstream exists, use `git push`.
+   - Do not push directly to `main`.
+   - Do not force-push unless the user explicitly asks and the risk is explained.
+
+7. Create or update the PR.
+   - Use the GitHub connector/app when available for PR creation and metadata. Use `gh` as a fallback when connector coverage is unavailable.
+   - Check for an existing PR for the branch before creating a duplicate.
+   - Default base branch: `main`.
+   - Default head branch: current branch.
+   - Create a draft PR only if the user asks for draft or the branch is intentionally not ready for review.
+   - Write a PR body with a short summary, verification performed, and any known risks or skipped checks.
+
+## PR Body Shape
+
+```markdown
+## Summary
+- ...
+
+## Verification
+- ...
+
+## Notes
+- ...
+```
+
+Omit `Notes` when there are no caveats. Include skipped checks under `Verification` rather than hiding them.
+
+## Final Response
+
+Report the commit hash, pushed branch, PR URL, checks run, and any skipped checks. In the Codex app, emit the required Git action directives after successful staging, commit, push, or PR creation.
+
+If the user changes their mind mid-request, honor the newest instruction and stop before taking irreversible Git actions.

--- a/.codex/skills/git-pr-publisher/agents/openai.yaml
+++ b/.codex/skills/git-pr-publisher/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Git PR Publisher"
+  short_description: "Publish a focused branch as a PR"
+  default_prompt: "Use $git-pr-publisher to stage, commit, push this branch, and open a PR against main."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,105 @@
+# AGENTS.md
+
+## Scope
+
+These instructions apply to the whole repository. This is Waffy Ahmed's React/Vite portfolio for `https://waffy.netlify.app/`.
+
+## Working Agreements
+
+- Check `git status --short` before making edits. Treat unrelated changes as user-owned and do not revert them.
+- Keep changes focused on the user request. Avoid opportunistic refactors, broad rewrites, or dependency churn.
+- Use the root `package.json` scripts unless there is a specific reason to work from `main/`.
+- Do not commit, push, deploy, or modify Git hooks unless the user explicitly asks.
+- Prefer ASCII for new prose and code unless an edited file already uses non-ASCII for the relevant text.
+- When a task matches a repo skill under `.codex/skills`, use that skill and follow its `SKILL.md` before editing.
+
+## Project Map
+
+- `main/` is the Vite React app.
+- `main/src/pages/` contains route-level pages.
+- `main/src/components/` contains reusable UI components.
+- `main/src/data/` is the canonical source for profile, experience, project, case-study, and route metadata content.
+- `main/src/utils/analytics.js` and `main/src/hooks/usePageTracking.jsx` own GA4 behavior.
+- `main/public/` contains static assets, resume files, sitemap, robots, redirects, AI-readable files, and structured public data.
+- `main/index.html` contains the static shell and JSON-LD profile data.
+- `netlify.toml` owns Netlify build settings, headers, and CSP.
+- `scripts/pre-push-checks.sh` runs the local pre-push lint, test, and build sequence.
+
+## Commands
+
+Run from the repository root:
+
+```bash
+npm run dev
+npm run lint
+npm run test
+npm run build
+npm run preview
+```
+
+Use focused checks when a repo skill provides one:
+
+```bash
+bash .codex/skills/portfolio-release-qa/scripts/portfolio_preflight.sh /Users/waffyahmed/Downloads/personalWebsite
+node .codex/skills/portfolio-content-sync/scripts/check_content_sync.mjs /Users/waffyahmed/Downloads/personalWebsite
+node .codex/skills/resume-site-sync/scripts/check_resume_assets.mjs /Users/waffyahmed/Downloads/personalWebsite
+node .codex/skills/seo-spa-auditor/scripts/check_spa_seo.mjs /Users/waffyahmed/Downloads/personalWebsite
+node .codex/skills/ai-discovery-maintainer/scripts/check_ai_discovery.mjs /Users/waffyahmed/Downloads/personalWebsite
+node .codex/skills/csp-security-header-maintainer/scripts/check_csp_jsonld_hash.mjs /Users/waffyahmed/Downloads/personalWebsite
+node .codex/skills/ga4-portfolio-analytics/scripts/check_ga4_events.mjs /Users/waffyahmed/Downloads/personalWebsite
+```
+
+## Verification Expectations
+
+- For code changes, run the narrowest meaningful check first, then `npm run lint`, `npm run test`, or `npm run build` as risk requires.
+- For release, push, or deploy readiness, use `$portfolio-release-qa` and run lint, tests, and production build.
+- For visual or layout work, start the dev or preview server and inspect the affected route on desktop and mobile widths when possible.
+- For route changes, smoke-check canonical lowercase routes and legacy uppercase redirects.
+- If a command cannot be run, report the reason and the remaining risk.
+
+## Skill Routing
+
+- Use `$portfolio-release-qa` for pre-push checks, release readiness, route smoke checks, build/test/lint verification, resume/static asset validation, or Netlify deploy readiness.
+- Use `$portfolio-content-sync` when changing profile, experience, projects, case studies, metrics, links, route slugs, public portfolio metadata, recruiter-facing copy, or AI/SEO-visible content.
+- Use `$resume-site-sync` when replacing, validating, linking, previewing, or summarizing the resume PDF or resume preview image.
+- Use `$seo-spa-auditor` when changing routes, canonical URLs, sitemap entries, robots, Open Graph/Twitter metadata, SPA redirects, case-study slugs, or link-preview behavior.
+- Use `$ai-discovery-maintainer` when changing `llms.txt`, `ai-summary.txt`, `portfolio.json`, JSON-LD, structured project/case-study metadata, or AI-agent discovery guidance.
+- Use `$csp-security-header-maintainer` when changing JSON-LD, Google Analytics, Formspree, external assets, security headers, CSP hashes, redirects, or frame/object/base policies.
+- Use `$ga4-portfolio-analytics` when adding, removing, auditing, testing, or documenting GA4 events.
+- Use `$git-pr-publisher` when asked to stage files, commit changes, push the current or dev branch, create or update a PR against `main`, or safely ship local changes after implementation.
+
+## Content And Metadata Rules
+
+- Preserve the portfolio voice: backend/platform engineering, production ownership, reliability, Kubernetes, observability, deployment automation, incident response, and measurable impact.
+- Keep `main/src/data/*` as the canonical app content source. When content changes, align the visible app, `main/public/portfolio.json`, `main/public/ai-summary.txt`, `main/public/llms.txt`, `main/public/sitemap.xml`, and `main/src/data/seo.js` as needed.
+- Keep public AI/discovery content focused on Waffy's engineering work, not the implementation details of the website itself.
+- Avoid trust-risk copy. In particular, do not imply Firestore stores user passwords; FirebaseAuth handles authentication, and Firestore stores profile metadata, saved jobs, and preferences.
+- Preserve canonical resume paths: `main/public/waffyAhmedResume.pdf` and `main/public/resume-preview.png`.
+- Keep canonical app routes lowercase. Maintain legacy uppercase redirects in React routes and Netlify redirects when route behavior changes.
+
+## Analytics Rules
+
+- Keep event emission in `main/src/utils/analytics.js`, `main/src/hooks/usePageTracking.jsx`, and the component that owns the user action.
+- Keep event tests in `main/src/App.test.jsx` near the behavior being tracked.
+- Use lowercase underscore event names and include useful `placement` values.
+- Do not send empty event params.
+- Recommended GA4 key-event candidates are `resume_download`, `contact_form_success`, `project_source_click`, and `case_study_link_click`.
+
+## Security And Netlify Rules
+
+- Inspect `netlify.toml` before changing external scripts, forms, images, frames, connections, redirects, or headers.
+- If JSON-LD in `main/index.html` changes, recompute and verify the CSP `script-src` SHA-256 hash.
+- Keep CSP narrow: allow only the site, the inline JSON-LD hash, Google Tag Manager/Analytics, Formspree, and currently required data font/image sources.
+- Do not add new third-party services or production dependencies without a clear reason and user approval.
+
+## Frontend Rules
+
+- Follow the existing React 18, React Router, Vite, Tailwind, and Testing Library patterns.
+- Keep route pages focused and compose reusable UI through `main/src/components/`.
+- Preserve accessibility basics: semantic headings, reachable links/buttons, focus behavior, and useful labels.
+- Make responsive changes deliberately. Check mobile and desktop layouts for text overflow, overlapping elements, and broken navigation.
+- Prefer existing visual language, spacing, and component patterns over adding a new design system.
+
+## Done Criteria
+
+Before finishing, summarize changed files, commands run, and any checks not run. If public content, SEO, AI discovery, resume, analytics, CSP, or routes changed, explicitly mention the corresponding alignment or verification step.


### PR DESCRIPTION
## Summary
- Add repo-level AGENTS.md guidance for Codex workflows, verification expectations, skill routing, and portfolio-specific rules.
- Add the repo-local git-pr-publisher skill for safe stage, commit, push, and PR publishing flows.

## Verification
- bash .codex/skills/portfolio-release-qa/scripts/portfolio_preflight.sh /Users/waffyahmed/Downloads/personalWebsite
- Pre-push hook also ran lint, tests, and production build successfully during git push.

## Notes
- Left unrelated untracked docs/portfolio-feedback-roadmap.md out of the commit.