### PR TITLE
Redesign portfolio into recruiter-focused Mission Control dashboard

### DIFF
--- a/main/src/App.jsx
+++ b/main/src/App.jsx
@@ -15,10 +15,10 @@ import usePageTracking from "./hooks/usePageTracking.jsx"
 function App() {
   usePageTracking()
   return (
-    <div className="flex min-h-screen w-full flex-col">
+    <div className="flex min-h-screen w-full flex-col bg-[#F4F1EA]">
       <Seo />
       <Navbar />
-      <div className="flex-1 overflow-auto bg-slate-100">
+      <div className="flex-1 overflow-auto">
         <Routes>
           <Route caseSensitive path="/" element={<Home />} />
           <Route caseSensitive path="/resume" element={<Resume />} />

--- a/main/src/components/ContactForm.jsx
+++ b/main/src/components/ContactForm.jsx
@@ -7,12 +7,12 @@ function ContactForm() {
 
   if (!formKey) {
     return (
-      <div className="w-full max-w-md md:max-w-2xl mx-auto border border-gray-300 rounded-lg p-6 mb-8 shadow-lg bg-blue-100 text-center">
-        <h2 className="text-2xl font-bold mb-4 text-gray-800">Contact Form</h2>
-        <p className="text-gray-700">
+      <div className="w-full rounded-2xl border border-white/10 bg-white/[0.08] p-6 text-center text-white">
+        <h2 className="mb-4 text-2xl font-black text-white">Contact Form</h2>
+        <p className="text-slate-300">
           The contact form is unavailable right now. Please email me at{" "}
           <a
-            className="font-bold text-blue-700 underline"
+            className="font-black text-[#FFB077] underline"
             href="mailto:waffyahmed@gmail.com"
             onClick={() =>
               trackLinkClick("contact_email_click", {
@@ -50,62 +50,82 @@ function ContactFormFields({ formKey }) {
   }, [state.succeeded])
 
   if (state.succeeded) {
-    return <p className="text-xl text-green-600 font-bold text-center mb-4">Thank you for your message! I will reach out as soon as possible!</p>
+    return (
+      <div className="rounded-2xl border border-white/10 bg-white/[0.08] p-6 text-center">
+        <p className="text-xl font-black text-emerald-300">
+          Thank you for your message! I will reach out as soon as possible!
+        </p>
+      </div>
+    )
   }
   return (
-    <div className="w-full max-w-md md:max-w-2xl mx-auto border border-gray-300 rounded-lg p-6 mb-8 shadow-lg bg-blue-100">
-      <h2 className="text-2xl font-bold mb-4 text-gray-800 text-center">Contact Form</h2>
+    <div className="w-full rounded-2xl border border-white/10 bg-white/[0.08] p-6 text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.06)]">
+      <h2 className="mb-5 text-center text-2xl font-black text-white">Contact Form</h2>
       <form onSubmit={handleTrackedSubmit}>
-        <div className="flex flex-col sm:flex-row mb-4 space-y-4 sm:space-y-0 sm:space-x-4">
-          <div className="w-full sm:w-1/2">
-            <label htmlFor="firstName" className="block text-gray-700 font-bold mb-2">First Name</label>
+        <div className="mb-4 grid gap-4 sm:grid-cols-2">
+          <div>
+            <label htmlFor="firstName" className="mb-2 block font-black text-slate-200">First Name</label>
             <input
               type="text"
               name="firstName"
               id="firstName"
               placeholder="Enter first name"
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white"
+              className="mc-field"
               required
             />
           </div>
-          <div className="w-full sm:w-1/2">
-            <label htmlFor="lastName" className="block text-gray-700 font-bold mb-2">Last Name</label>
+          <div>
+            <label htmlFor="lastName" className="mb-2 block font-black text-slate-200">Last Name</label>
             <input
               type="text"
               name="lastName"
               id="lastName"
               placeholder="Enter last name"
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white"
+              className="mc-field"
               required
             />
           </div>
         </div>
         <div className="mb-4">
-          <label htmlFor="email" className="block text-gray-700 font-bold mb-2">Email</label>
+          <label htmlFor="email" className="mb-2 block font-black text-slate-200">Email</label>
           <input
             type="email"
             name="email"
             id="email"
             placeholder="Enter email"
-            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white"
+            className="mc-field"
             required
           />
-          <ValidationError prefix="Email" field="email" errors={state.errors} />
+          <ValidationError
+            prefix="Email"
+            field="email"
+            errors={state.errors}
+            className="mt-2 text-sm font-bold text-[#FFB077]"
+          />
         </div>
         <div className="mb-4">
-          <label htmlFor="message" className="block text-gray-700 font-bold mb-2">Message</label>
+          <label htmlFor="message" className="mb-2 block font-black text-slate-200">Message</label>
           <textarea
             id="message"
             name="message"
             placeholder="Enter message"
-            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white"
+            className="mc-field min-h-36"
             rows="4"
             required
           />
-          <ValidationError prefix="Message" field="message" errors={state.errors} />
+          <ValidationError
+            prefix="Message"
+            field="message"
+            errors={state.errors}
+            className="mt-2 text-sm font-bold text-[#FFB077]"
+          />
         </div>
-        <div className="flex justify-center">
-          <button type="submit" disabled={state.submitting} className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
+        <div className="flex justify-end">
+          <button
+            type="submit"
+            disabled={state.submitting}
+            className="mc-button-primary px-5 disabled:cursor-not-allowed disabled:opacity-60"
+          >
             Send Message
           </button>
         </div>

--- a/main/src/components/DeployDates.jsx
+++ b/main/src/components/DeployDates.jsx
@@ -71,45 +71,46 @@ function DeployDates({ first }) {
   };
 
   return (
-    <div className="mt-3 text-center text-gray-700">
-      <p>Created: {firstDate}</p>
-      <p>Last Updated: {lastDate}</p>
+    <footer className="mc-panel-dark mt-4 flex flex-col gap-4 p-4 text-sm text-slate-300 sm:flex-row sm:items-center sm:justify-between">
+      <div className="grid gap-1">
+        <p>
+          <span className="font-black text-white">Created:</span> {firstDate}
+        </p>
+        <p>
+          <span className="font-black text-white">Last updated:</span> {lastDate}
+        </p>
+        <p className="text-xs text-slate-500">© {year} Waffy Ahmed</p>
+      </div>
 
-      {/* AI Summary Section */}
-      <div className="mt-2 text-sm text-gray-600">
-        <p>View an AI-generated summary of this portfolio</p>
-
-        <div className="flex justify-center gap-6 mt-2">
+      <div className="flex items-center gap-3">
+        <p className="text-xs font-black uppercase text-[#93B4FF]">AI brief</p>
+        <div className="flex gap-2">
           {AI_PROVIDERS.map((provider) => (
-            <div
-              key={provider.name}
-              className="relative flex flex-col items-center group"
-            >
+            <div key={provider.name} className="group relative flex items-center">
               <button
+                type="button"
                 onClick={() => handleAIAction(provider)}
                 aria-label={provider.label}
-                className="transition-transform hover:scale-110"
+                className="flex h-10 w-10 items-center justify-center rounded-md border border-white/10 bg-white/10 transition hover:border-[#2563EB] hover:bg-white/15 focus:outline-none focus:ring-2 focus:ring-[#2563EB] focus:ring-offset-2 focus:ring-offset-[#0B1220]"
               >
                 <img
                   src={provider.icon}
-                  alt={provider.label}
-                  className="h-6 w-6 opacity-80 hover:opacity-100 transition"
+                  alt=""
+                  aria-hidden="true"
+                  className="h-5 w-5 opacity-90"
                 />
               </button>
 
-              {/* Tooltip */}
-              <div className="absolute top-full mt-2 pointer-events-none">
+              <div className="pointer-events-none absolute right-0 top-full mt-2">
                 <span
-                  className={`whitespace-nowrap text-xs bg-white/95 text-gray-700
-                  px-2 py-1 rounded shadow-sm transition-all duration-150
-                  ${
+                  className={`whitespace-nowrap rounded bg-white px-2 py-1 text-xs font-bold text-slate-700 shadow-sm transition-all duration-150 ${
                     copiedProvider === provider.name
-                      ? "opacity-100 translate-y-0"
-                      : "opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0"
+                      ? "translate-y-0 opacity-100"
+                      : "translate-y-1 opacity-0 group-hover:translate-y-0 group-hover:opacity-100"
                   }`}
                 >
                   {copiedProvider === provider.name
-                    ? "Copied!"
+                    ? "Copied"
                     : provider.name === "chatgpt"
                     ? "ChatGPT"
                     : "Claude"}
@@ -119,11 +120,7 @@ function DeployDates({ first }) {
           ))}
         </div>
       </div>
-
-      <p className="mt-3 text-xs text-gray-500">
-        © {year} Waffy Ahmed
-      </p>
-    </div>
+    </footer>
   );
 }
 

--- a/main/src/components/ExperienceCard.jsx
+++ b/main/src/components/ExperienceCard.jsx
@@ -29,18 +29,21 @@ const ExperienceCard = ({
     ? "border-[#F96302]/35 bg-[#F96302]"
     : "border-[#2563EB]/35 bg-[#2563EB]";
   const cardHeightClass = featured
-    ? "min-h-[34rem] lg:h-full lg:min-h-[42rem]"
+    ? "min-h-[30rem] lg:min-h-[36rem]"
     : "min-h-[24rem]";
   const logoBayClass = useStandaloneLogo
-    ? "my-5 flex flex-1 items-center justify-center"
+    ? "my-5 flex flex-1 items-start justify-center pt-4 lg:pt-6"
     : featured
     ? "my-5 flex flex-1 items-start justify-center rounded-2xl border p-8 pt-10"
     : "my-5 flex flex-1 items-center justify-center rounded-2xl border p-6";
   const logoImageClass = useStandaloneLogo
-    ? "h-56 w-56 object-contain"
+    ? "h-44 w-44 object-contain sm:h-52 sm:w-52"
     : featured
     ? "max-h-52 max-w-[82%] object-contain shadow-[0_18px_42px_rgba(11,18,32,0.28)]"
     : "max-h-32 max-w-[70%] object-contain";
+  const detailsButtonClass = featured
+    ? "mc-button-light mt-3 w-full sm:w-fit"
+    : "mc-button-light mt-auto w-full sm:w-fit";
 
   const handleCopy = async () => {
     try {
@@ -57,7 +60,7 @@ const ExperienceCard = ({
   };
 
   return (
-    <article className={`w-full ${cardHeightClass} perspective`}>
+    <article className={`w-full ${featured ? "lg:self-center" : ""} ${cardHeightClass} perspective`}>
       <div
         className={`relative ${cardHeightClass} w-full transition-transform duration-500 transform-style-preserve-3d motion-reduce:transition-none ${
           isFlipped ? "rotate-y-180" : ""
@@ -106,7 +109,7 @@ const ExperienceCard = ({
             aria-label={`Show details for ${title} at ${company}`}
             aria-expanded={isFlipped}
             aria-controls={detailsId}
-            className="mc-button-light mt-auto w-full sm:w-fit"
+            className={detailsButtonClass}
           >
             <FaInfoCircle className="mr-2" aria-hidden="true" />
             Details

--- a/main/src/components/ExperienceCard.jsx
+++ b/main/src/components/ExperienceCard.jsx
@@ -1,12 +1,46 @@
 import React, { useId, useState } from "react";
 import { FaArrowLeft, FaCheck, FaClipboard, FaInfoCircle } from "react-icons/fa";
+import { StatusBadge } from "./MissionControl.jsx";
 
-const ExperienceCard = ({ title, company, location, date, bullets, logo, color }) => {
+const ExperienceCard = ({
+  title,
+  company,
+  location,
+  date,
+  bullets,
+  logo,
+  featured = false,
+}) => {
   const [isFlipped, setIsFlipped] = useState(false);
   const [copyStatus, setCopyStatus] = useState(null);
   const cardId = useId();
   const titleId = `${cardId}-title`;
   const detailsId = `${cardId}-details`;
+  const isHomeDepot = company === "The Home Depot";
+  const useStandaloneLogo = featured && isHomeDepot;
+  const accentClass = isHomeDepot ? "bg-[#F96302]" : "bg-[#2563EB]";
+  const accentTextClass = isHomeDepot ? "text-[#FFB077]" : "text-[#93B4FF]";
+  const frontFaceClass = featured
+    ? "border-white/10 bg-[#111827]"
+    : "border-white/10 bg-white/[0.065]";
+  const logoTileClass = useStandaloneLogo
+    ? ""
+    : isHomeDepot
+    ? "border-[#F96302]/35 bg-[#F96302]"
+    : "border-[#2563EB]/35 bg-[#2563EB]";
+  const cardHeightClass = featured
+    ? "min-h-[34rem] lg:h-full lg:min-h-[42rem]"
+    : "min-h-[24rem]";
+  const logoBayClass = useStandaloneLogo
+    ? "my-5 flex flex-1 items-center justify-center"
+    : featured
+    ? "my-5 flex flex-1 items-start justify-center rounded-2xl border p-8 pt-10"
+    : "my-5 flex flex-1 items-center justify-center rounded-2xl border p-6";
+  const logoImageClass = useStandaloneLogo
+    ? "h-56 w-56 object-contain"
+    : featured
+    ? "max-h-52 max-w-[82%] object-contain shadow-[0_18px_42px_rgba(11,18,32,0.28)]"
+    : "max-h-32 max-w-[70%] object-contain";
 
   const handleCopy = async () => {
     try {
@@ -23,37 +57,48 @@ const ExperienceCard = ({ title, company, location, date, bullets, logo, color }
   };
 
   return (
-    <article className="w-full min-h-[23rem] perspective">
+    <article className={`w-full ${cardHeightClass} perspective`}>
       <div
-        className={`relative min-h-[23rem] w-full transition-transform duration-500 transform-style-preserve-3d ${
+        className={`relative ${cardHeightClass} w-full transition-transform duration-500 transform-style-preserve-3d motion-reduce:transition-none ${
           isFlipped ? "rotate-y-180" : ""
         }`}
       >
-        {/* Front Side */}
         <div
           aria-hidden={isFlipped}
-          className={`absolute inset-0 backface-hidden ${color} bg-opacity-90 rounded-lg shadow-md p-4 flex flex-col ${
+          className={`absolute inset-0 flex flex-col overflow-hidden rounded-2xl border p-5 text-white backface-hidden ${frontFaceClass} ${
             isFlipped ? "pointer-events-none" : ""
           }`}
         >
-          <div className="flex flex-col flex-shrink-0">
-            <div className="flex justify-between items-center mb-2">
-              <h3 id={titleId} className="text-xl font-bold text-gray-800 max-w-[60%]">{title}</h3>
-              <p className="text-lg text-gray-600">{date}</p>
+          <div className={`absolute inset-x-0 top-0 h-1 ${accentClass}`} aria-hidden="true" />
+
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <StatusBadge
+                tone={isHomeDepot ? "orange" : "cyan"}
+                className="border-white/15 bg-white/10 text-slate-100"
+              >
+                {isHomeDepot ? "Production platform" : "Engineering signal"}
+              </StatusBadge>
+              <h3 id={titleId} className="mt-4 text-2xl font-black leading-tight text-white">
+                {title}
+              </h3>
+              <p className={`mt-2 text-base font-black ${accentTextClass}`}>{company}</p>
             </div>
-            <div className="flex justify-between items-center mb-2">
-              <p className="text-lg text-gray-600">{company}</p>
-              <p className="text-lg text-gray-600">{location}</p>
+            <div className="text-right text-sm font-bold text-slate-300">
+              <p>{date}</p>
+              <p className="mt-1">{location}</p>
             </div>
           </div>
-          <div className="flex flex-1 items-center justify-center py-4">
+
+          <div className={`${logoBayClass} ${logoTileClass}`}>
             <img
               src={logo}
               alt=""
               aria-hidden="true"
-              className="max-h-36 max-w-[70%] object-contain"
+              className={logoImageClass}
             />
           </div>
+
           <button
             type="button"
             onClick={() => setIsFlipped(true)}
@@ -61,60 +106,66 @@ const ExperienceCard = ({ title, company, location, date, bullets, logo, color }
             aria-label={`Show details for ${title} at ${company}`}
             aria-expanded={isFlipped}
             aria-controls={detailsId}
-            className="mt-auto inline-flex w-full items-center justify-center rounded bg-white/85 px-4 py-3 text-sm font-bold text-gray-700 shadow-sm transition-colors hover:bg-white focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 sm:w-fit sm:justify-start sm:py-2"
+            className="mc-button-light mt-auto w-full sm:w-fit"
           >
-            <FaInfoCircle className="mr-2" />
+            <FaInfoCircle className="mr-2" aria-hidden="true" />
             Details
           </button>
         </div>
 
-        {/* Back Side */}
         <div
           id={detailsId}
           role="region"
           aria-hidden={!isFlipped}
           aria-labelledby={`${detailsId}-heading`}
-          className={`absolute inset-0 backface-hidden ${color} bg-opacity-85 rounded-lg shadow-md p-4 flex flex-col rotate-y-180 ${
+          className={`absolute inset-0 flex flex-col overflow-hidden rounded-2xl border border-[#2563EB]/35 bg-[#0B1220] p-5 text-white backface-hidden rotate-y-180 ${
             isFlipped ? "" : "pointer-events-none"
           }`}
         >
-          
-          {/* Copy Button Top-Right */}
-          <div className="absolute top-4 right-4 z-10 flex flex-col items-center group">
+          <div className="absolute right-4 top-4 z-10 flex flex-col items-center group">
             <button
               type="button"
               onClick={handleCopy}
               tabIndex={isFlipped ? 0 : -1}
               aria-label={`Copy ${title} details`}
-              className="p-2 rounded-full bg-white shadow-md hover:shadow-lg hover:scale-110 transform transition-all duration-200 flex items-center justify-center"
+              className="relative flex h-10 w-10 items-center justify-center rounded-md border border-white/10 bg-white/10 text-white transition hover:border-[#2563EB] hover:bg-white/15 focus:outline-none focus:ring-2 focus:ring-[#2563EB] focus:ring-offset-2 focus:ring-offset-[#0B1220]"
             >
               <FaClipboard
-                className={`h-5 w-5 transition-opacity duration-200 ${copyStatus === "success" ? "opacity-0" : "opacity-100"}`}
+                className={`h-4 w-4 transition-opacity duration-200 ${
+                  copyStatus === "success" ? "opacity-0" : "opacity-100"
+                }`}
+                aria-hidden="true"
               />
               <FaCheck
-                className={`absolute h-5 w-5 text-green-500 transition-opacity duration-200 ${copyStatus === "success" ? "opacity-100" : "opacity-0"}`}
+                className={`absolute h-4 w-4 text-emerald-300 transition-opacity duration-200 ${
+                  copyStatus === "success" ? "opacity-100" : "opacity-0"
+                }`}
+                aria-hidden="true"
               />
             </button>
 
-            {/* Tooltip */}
             <span
-              className={`mt-1 text-xs text-gray-700 bg-white/90 px-2 py-1 rounded shadow-sm transform transition-all duration-200
-                ${copyStatus ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-2"} 
-                group-hover:opacity-100 group-hover:translate-y-0`}
+              className={`mt-2 rounded bg-white px-2 py-1 text-xs font-bold text-slate-700 shadow-sm transition-all duration-200 ${
+                copyStatus
+                  ? "translate-y-0 opacity-100"
+                  : "-translate-y-1 opacity-0 group-hover:translate-y-0 group-hover:opacity-100"
+              }`}
             >
-              {copyStatus === "success" ? "Copied!" : copyStatus === "error" ? "Copy failed" : "Copy"}
+              {copyStatus === "success" ? "Copied" : copyStatus === "error" ? "Copy failed" : "Copy"}
             </span>
           </div>
 
-          <h3 id={`${detailsId}-heading`} className="text-xl font-semibold mb-4 mt-1 pr-14">Experience Details</h3>
+          <p className="text-xs font-black uppercase text-[#93B4FF]">Operational record</p>
+          <h3 id={`${detailsId}-heading`} className="mt-2 pr-16 text-xl font-black">
+            Experience Details
+          </h3>
 
-          {/* Scrollable bullets area */}
-          <div className="flex-1 overflow-y-auto pr-2 pt-2">
-            <ul className="list-none pl-0 space-y-2">
+          <div className="mt-4 flex-1 overflow-y-auto pr-2">
+            <ul className="space-y-3">
               {bullets.map((bullet, index) => (
-                <li key={index} className="text-gray-700 flex">
-                  <span className="mr-2 flex-shrink-0">•</span>
-                  <span className="flex-1">{bullet}</span>
+                <li key={index} className="flex gap-3 text-sm leading-relaxed text-slate-200">
+                  <span className={`mt-1 h-2 w-2 shrink-0 rounded-full ${accentClass}`} />
+                  <span>{bullet}</span>
                 </li>
               ))}
             </ul>
@@ -125,9 +176,9 @@ const ExperienceCard = ({ title, company, location, date, bullets, logo, color }
             onClick={() => setIsFlipped(false)}
             tabIndex={isFlipped ? 0 : -1}
             aria-label={`Hide details for ${title} at ${company}`}
-            className="mt-3 inline-flex w-full items-center justify-center rounded bg-white/85 px-4 py-3 text-sm font-bold text-gray-700 shadow-sm transition-colors hover:bg-white focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 sm:w-fit sm:justify-start sm:py-2"
+            className="mt-4 inline-flex w-full items-center justify-center rounded-md border border-white/15 bg-white/10 px-4 py-3 text-sm font-black text-white transition hover:border-[#2563EB] hover:bg-white/15 focus:outline-none focus:ring-2 focus:ring-[#2563EB] focus:ring-offset-2 focus:ring-offset-[#0B1220] sm:w-fit sm:py-2"
           >
-            <FaArrowLeft className="mr-2" />
+            <FaArrowLeft className="mr-2" aria-hidden="true" />
             Back
           </button>
         </div>

--- a/main/src/components/MissionControl.jsx
+++ b/main/src/components/MissionControl.jsx
@@ -1,0 +1,273 @@
+import React from "react"
+
+const toneClasses = {
+  cyan: {
+    text: "text-[#1d4ed8]",
+    icon: "text-[#2563EB]",
+    border: "border-[#2563EB]/30",
+    bg: "bg-[#2563EB]/10",
+    dot: "bg-[#2563EB]",
+  },
+  green: {
+    text: "text-[#147a56]",
+    icon: "text-[#20A875]",
+    border: "border-[#20A875]/35",
+    bg: "bg-[#20A875]/10",
+    dot: "bg-[#20A875]",
+  },
+  orange: {
+    text: "text-[#b94600]",
+    icon: "text-[#F96302]",
+    border: "border-[#F96302]/35",
+    bg: "bg-[#F96302]/10",
+    dot: "bg-[#F96302]",
+  },
+  zinc: {
+    text: "text-[#334155]",
+    icon: "text-[#475569]",
+    border: "border-slate-300",
+    bg: "bg-slate-100",
+    dot: "bg-[#475569]",
+  },
+}
+
+const nodeToneClasses = {
+  blue: "mc-system-node-blue",
+  green: "mc-system-node-green",
+  orange: "mc-system-node-orange",
+  purple: "mc-system-node-purple",
+}
+
+const diagramPositions = [
+  "sm:left-[7%] sm:top-[8%]",
+  "sm:left-1/2 sm:top-[5%] sm:-translate-x-1/2",
+  "sm:right-[7%] sm:top-[8%]",
+  "sm:left-[3%] sm:top-1/2 sm:-translate-y-1/2",
+  "sm:right-[3%] sm:top-1/2 sm:-translate-y-1/2",
+  "sm:left-[10%] sm:bottom-[7%]",
+  "sm:left-1/2 sm:bottom-[5%] sm:-translate-x-1/2",
+  "sm:right-[10%] sm:bottom-[7%]",
+]
+
+export function PageShell({ children, className = "" }) {
+  return <main className={`mc-page ${className}`}>{children}</main>
+}
+
+export function PageContainer({ children, className = "" }) {
+  return (
+    <div className={`relative z-10 mx-auto w-full max-w-6xl px-4 py-10 sm:py-12 ${className}`}>
+      {children}
+    </div>
+  )
+}
+
+export function PresentationPanel({
+  children,
+  className = "",
+  as: Component = "section",
+  ...props
+}) {
+  return (
+    <Component className={`mc-presentation-panel ${className}`} {...props}>
+      {children}
+    </Component>
+  )
+}
+
+export function SectionHeader({
+  eyebrow,
+  title,
+  description,
+  action,
+  align = "left",
+  tone = "light",
+  className = "",
+}) {
+  const alignment = align === "center" ? "mx-auto text-center" : ""
+  const isDark = tone === "dark"
+  const titleClass = isDark ? "text-white" : "text-[#0B1220]"
+  const descriptionClass = isDark ? "text-slate-300" : "text-slate-600"
+
+  return (
+    <header className={`mb-8 ${alignment} ${className}`}>
+      {eyebrow ? <p className="mc-eyebrow">{eyebrow}</p> : null}
+      <div className={align === "center" ? "mx-auto max-w-3xl" : "max-w-4xl"}>
+        <h1 className={`text-4xl font-black leading-tight sm:text-5xl ${titleClass}`}>
+          {title}
+        </h1>
+        {description ? (
+          <p className={`mt-4 max-w-3xl text-base leading-relaxed sm:text-lg ${descriptionClass}`}>
+            {description}
+          </p>
+        ) : null}
+      </div>
+      {action ? <div className="mt-5">{action}</div> : null}
+    </header>
+  )
+}
+
+export function StatusBadge({ children, tone = "green", className = "" }) {
+  const toneClass = toneClasses[tone] ?? toneClasses.green
+
+  return (
+    <span
+      className={`inline-flex items-center gap-2 rounded-full border ${toneClass.border} ${toneClass.bg} px-3 py-1 text-xs font-bold ${toneClass.text} ${className}`}
+    >
+      <span className={`h-2 w-2 rounded-full ${toneClass.dot}`} />
+      {children}
+    </span>
+  )
+}
+
+export function SignalCard({
+  label,
+  title,
+  detail,
+  tone = "orange",
+  className = "",
+}) {
+  const toneClass = toneClasses[tone] ?? toneClasses.orange
+
+  return (
+    <article className={`mc-signal-card ${className}`}>
+      <p className={`text-xs font-black uppercase tracking-[0.18em] ${toneClass.text}`}>
+        {label}
+      </p>
+      <h3 className="mt-4 text-xl font-black leading-tight text-white">{title}</h3>
+      {detail ? <p className="mt-3 text-sm leading-relaxed text-slate-300">{detail}</p> : null}
+    </article>
+  )
+}
+
+export function MetricTile({
+  value,
+  label,
+  detail,
+  icon: Icon,
+  tone = "cyan",
+  className = "",
+}) {
+  const toneClass = toneClasses[tone] ?? toneClasses.cyan
+
+  return (
+    <div className={`mc-panel p-5 ${className}`}>
+      <div className="mb-3 flex items-center justify-between gap-3">
+        {Icon ? <Icon className={`h-5 w-5 ${toneClass.icon}`} aria-hidden="true" /> : null}
+        <span className={`h-px flex-1 ${toneClass.bg}`} aria-hidden="true" />
+      </div>
+      <p className={`text-3xl font-black leading-none ${toneClass.text}`}>{value}</p>
+      <p className="mt-2 text-sm font-bold text-[#0B1220]">{label}</p>
+      {detail ? <p className="mt-2 text-sm leading-relaxed text-slate-600">{detail}</p> : null}
+    </div>
+  )
+}
+
+export function ImpactBand({
+  items,
+  className = "",
+  surface = "light",
+}) {
+  const isDark = surface === "dark"
+
+  return (
+    <section
+      aria-label="Impact metrics"
+      className={`mc-impact-band ${isDark ? "mc-impact-band-dark" : ""} ${className}`}
+    >
+      {items.map((item, index) => (
+        <div
+          key={`${item.value}-${item.label}`}
+          className={`min-w-0 px-0 py-4 sm:px-5 ${
+            index > 0 ? "border-t border-current/15 sm:border-l sm:border-t-0" : ""
+          }`}
+        >
+          <p className={item.tone === "orange" ? "mc-impact-value-orange" : "mc-impact-value"}>
+            {item.value}
+          </p>
+          <p className={isDark ? "mt-2 text-sm font-black uppercase text-slate-300" : "mt-2 text-sm font-black uppercase text-slate-700"}>
+            {item.label}
+          </p>
+          {item.detail ? (
+            <p className={isDark ? "mt-2 text-sm leading-relaxed text-slate-400" : "mt-2 text-sm leading-relaxed text-slate-600"}>
+              {item.detail}
+            </p>
+          ) : null}
+        </div>
+      ))}
+    </section>
+  )
+}
+
+export function StackChips({ items, className = "" }) {
+  return (
+    <div className={`flex flex-wrap gap-2 ${className}`}>
+      {items.map((item) => (
+        <span key={item} className="mc-chip">
+          {item}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+export function SystemDiagram({
+  centerLabel,
+  centerDetail,
+  nodes,
+  caption,
+  className = "",
+}) {
+  const visibleNodes = nodes.slice(0, diagramPositions.length)
+
+  return (
+    <figure className={`mc-system-diagram ${className}`}>
+      <div className="relative z-10 grid grid-cols-2 gap-3 sm:block sm:min-h-[24rem]">
+        <div className="pointer-events-none absolute inset-0 hidden sm:block" aria-hidden="true">
+          <span className="mc-system-link left-[28%] top-[29%] w-[20%] rotate-[34deg]" />
+          <span className="mc-system-link right-[28%] top-[29%] w-[20%] -rotate-[34deg]" />
+          <span className="mc-system-link left-[24%] top-1/2 w-[24%]" />
+          <span className="mc-system-link right-[24%] top-1/2 w-[24%]" />
+          <span className="mc-system-link bottom-[28%] left-[28%] w-[20%] -rotate-[34deg]" />
+          <span className="mc-system-link bottom-[28%] right-[28%] w-[20%] rotate-[34deg]" />
+          <span className="mc-system-link left-1/2 top-[29%] w-[18%] -translate-x-1/2 rotate-90" />
+          <span className="mc-system-link bottom-[29%] left-1/2 w-[18%] -translate-x-1/2 rotate-90" />
+        </div>
+
+        <div className="mc-system-hub col-span-2 sm:absolute sm:left-1/2 sm:top-1/2 sm:w-[12.5rem] sm:-translate-x-1/2 sm:-translate-y-1/2">
+          {centerDetail ? (
+            <p className="text-[0.64rem] font-black uppercase tracking-[0.18em] text-[#FFB077]">
+              {centerDetail}
+            </p>
+          ) : null}
+          <p className="mt-2 text-xl font-black leading-tight text-white">{centerLabel}</p>
+        </div>
+
+        {visibleNodes.map((node, index) => {
+          const Icon = node.icon
+          const toneClass = nodeToneClasses[node.tone] ?? nodeToneClasses.blue
+
+          return (
+            <div
+              key={`${node.label}-${index}`}
+              className={`mc-system-node ${toneClass} sm:absolute sm:w-[8.6rem] ${diagramPositions[index]}`}
+            >
+              {Icon ? <Icon className="h-5 w-5" aria-hidden="true" /> : null}
+              <p className="mt-3 text-sm font-black leading-tight text-white">{node.label}</p>
+              {node.detail ? (
+                <p className="mt-1 text-xs font-bold leading-snug text-slate-300">
+                  {node.detail}
+                </p>
+              ) : null}
+            </div>
+          )
+        })}
+      </div>
+
+      {caption ? (
+        <figcaption className="relative z-10 mt-4 border-t border-white/10 pt-4 text-sm font-bold leading-relaxed text-slate-300">
+          {caption}
+        </figcaption>
+      ) : null}
+    </figure>
+  )
+}

--- a/main/src/components/Navbar.jsx
+++ b/main/src/components/Navbar.jsx
@@ -1,15 +1,39 @@
-import { NavLink } from "react-router-dom";
+import { useEffect, useRef } from "react";
+import { NavLink, useLocation } from "react-router-dom";
 
 const navItems = [
   { to: "/", label: "Home" },
   { to: "/projects", label: "Projects" },
   { to: "/experience", label: "Experience" },
-  { to: "/case-studies", label: "Case Studies" },
+  { to: "/case-studies", label: "Case Studies", shortLabel: "Cases" },
   { to: "/resume", label: "Resume" },
   { to: "/contact", label: "Contact" },
 ];
 
 function Navbar() {
+  const location = useLocation();
+  const navRef = useRef(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) {
+      return;
+    }
+
+    const activeLink = navRef.current?.querySelector("[aria-current='page']");
+
+    if (!activeLink || window.matchMedia("(min-width: 640px)").matches) {
+      return;
+    }
+
+    const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+    activeLink.scrollIntoView({
+      behavior: prefersReducedMotion ? "auto" : "smooth",
+      block: "nearest",
+      inline: "nearest",
+    });
+  }, [location.pathname]);
+
   return (
     <header className="sticky top-0 z-50 border-b border-slate-900/10 bg-[#F4F1EA]/92 px-4 py-3 shadow-[0_12px_30px_rgba(11,18,32,0.08)] backdrop-blur">
       <div className="mx-auto flex max-w-6xl flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
@@ -28,8 +52,9 @@ function Navbar() {
         </NavLink>
 
         <nav
+          ref={navRef}
           aria-label="Primary navigation"
-          className="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm font-bold"
+          className="-mx-1 flex max-w-full flex-nowrap items-center gap-2 overflow-x-auto px-1 pb-1 text-xs font-bold whitespace-nowrap [scrollbar-width:none] sm:mx-0 sm:flex-wrap sm:justify-end sm:gap-x-4 sm:overflow-visible sm:px-0 sm:pb-0 sm:text-sm sm:[scrollbar-width:auto] [&::-webkit-scrollbar]:hidden sm:[&::-webkit-scrollbar]:block"
         >
           {navItems.map((item) => (
             <NavLink
@@ -37,14 +62,21 @@ function Navbar() {
               to={item.to}
               className={({ isActive }) =>
                 [
-                  "group relative py-1.5 text-slate-600 transition hover:text-[#0B1220] focus:outline-none focus:ring-2 focus:ring-[#2563EB] focus:ring-offset-2",
+                  "group relative shrink-0 rounded-md px-2 py-1.5 text-slate-600 transition hover:bg-[#0B1220]/5 hover:text-[#0B1220] focus:outline-none focus:ring-2 focus:ring-[#2563EB] focus:ring-offset-2 sm:rounded-none sm:px-0 sm:hover:bg-transparent",
                   isActive
                     ? "active text-[#0B1220]"
                     : "",
                 ].join(" ")
               }
             >
-              {item.label}
+              {item.shortLabel ? (
+                <>
+                  <span className="sm:hidden">{item.shortLabel}</span>
+                  <span className="hidden sm:inline">{item.label}</span>
+                </>
+              ) : (
+                item.label
+              )}
               <span className="absolute inset-x-0 -bottom-0.5 h-0.5 origin-left scale-x-0 bg-[#F96302] transition group-hover:scale-x-100 group-[.active]:scale-x-100" />
             </NavLink>
           ))}

--- a/main/src/components/Navbar.jsx
+++ b/main/src/components/Navbar.jsx
@@ -1,76 +1,56 @@
 import { NavLink } from "react-router-dom";
 
+const navItems = [
+  { to: "/", label: "Home" },
+  { to: "/projects", label: "Projects" },
+  { to: "/experience", label: "Experience" },
+  { to: "/case-studies", label: "Case Studies" },
+  { to: "/resume", label: "Resume" },
+  { to: "/contact", label: "Contact" },
+];
+
 function Navbar() {
   return (
-    <div className="w-full bg-[#6493bb] px-4 py-2">
-      <div className='flex flex-wrap justify-center gap-x-4 gap-y-2 text-sm sm:text-base font-["Cambria",_serif]'>
+    <header className="sticky top-0 z-50 border-b border-slate-900/10 bg-[#F4F1EA]/92 px-4 py-3 shadow-[0_12px_30px_rgba(11,18,32,0.08)] backdrop-blur">
+      <div className="mx-auto flex max-w-6xl flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <NavLink
           to="/"
-          className={({ isActive }) =>
-            isActive
-              ? "text-slate-100 font-bold underline"
-              : "font-bold text-slate-900 hover:text-slate-100"
-          }
+          className="group inline-flex items-center gap-3 text-[#0B1220] focus:outline-none focus:ring-2 focus:ring-[#2563EB] focus:ring-offset-2"
+          aria-label="Waffy Ahmed home"
         >
-          Home
+          <span className="flex h-10 w-10 items-center justify-center rounded-md border border-[#0B1220] bg-[#0B1220] font-black text-white transition group-hover:border-[#F96302] group-hover:bg-[#F96302]">
+            WA
+          </span>
+          <span className="leading-tight">
+            <span className="block text-sm font-black">Waffy Ahmed</span>
+            <span className="block text-xs font-bold text-slate-500">Platform reliability engineer</span>
+          </span>
         </NavLink>
 
-        <NavLink
-          to="/projects"
-          className={({ isActive }) =>
-            isActive
-              ? "text-slate-100 font-bold underline"
-              : "font-bold text-slate-900 hover:text-slate-100"
-          }
+        <nav
+          aria-label="Primary navigation"
+          className="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm font-bold"
         >
-          Projects
-        </NavLink>
-
-        <NavLink
-          to="/experience"
-          className={({ isActive }) =>
-            isActive
-              ? "text-slate-100 font-bold underline"
-              : "font-bold text-slate-900 hover:text-slate-100"
-          }
-        >
-          Experience
-        </NavLink>
-
-        <NavLink
-          to="/case-studies"
-          className={({ isActive }) =>
-            isActive
-              ? "text-slate-100 font-bold underline"
-              : "font-bold text-slate-900 hover:text-slate-100"
-          }
-        >
-          Case Studies
-        </NavLink>
-
-        <NavLink
-          to="/resume"
-          className={({ isActive }) =>
-            isActive
-              ? "text-slate-100 font-bold underline"
-              : "font-bold text-slate-900 hover:text-slate-100"
-          }
-        >
-          Resume
-        </NavLink>
-
-        <NavLink
-          to="/contact"
-          className={({ isActive }) =>
-            isActive
-              ? "text-slate-100 font-bold underline"
-              : "font-bold text-slate-900 hover:text-slate-100"
-          }
-        >
-          Contact
-        </NavLink>
+          {navItems.map((item) => (
+            <NavLink
+              key={item.to}
+              to={item.to}
+              className={({ isActive }) =>
+                [
+                  "group relative py-1.5 text-slate-600 transition hover:text-[#0B1220] focus:outline-none focus:ring-2 focus:ring-[#2563EB] focus:ring-offset-2",
+                  isActive
+                    ? "active text-[#0B1220]"
+                    : "",
+                ].join(" ")
+              }
+            >
+              {item.label}
+              <span className="absolute inset-x-0 -bottom-0.5 h-0.5 origin-left scale-x-0 bg-[#F96302] transition group-hover:scale-x-100 group-[.active]:scale-x-100" />
+            </NavLink>
+          ))}
+        </nav>
       </div>
-    </div>
+    </header>
   );
 }
 

--- a/main/src/components/OwnershipCard.jsx
+++ b/main/src/components/OwnershipCard.jsx
@@ -16,81 +16,44 @@ const OwnershipCard = ({ title, summary, icon, details }) => {
       onFocus={() => setIsHovered(true)}
       onBlur={handleBlur}
       tabIndex={0}
-      className={`
-        relative min-h-[190px] cursor-default overflow-visible rounded-xl outline-none
-        transition-all duration-500 ease-out
-        focus-visible:ring-2 focus-visible:ring-blue-600
-        focus-visible:ring-offset-2 focus-visible:ring-offset-blue-300
-        ${isHovered ? "z-20" : "z-0"}
-      `}
+      className={`relative min-h-[210px] rounded-lg outline-none transition-all duration-300 focus-visible:ring-2 focus-visible:ring-[#2563EB] focus-visible:ring-offset-2 ${
+        isHovered ? "z-20" : "z-0"
+      }`}
     >
       <div
-        className={`
-          relative min-h-[190px] p-6 border backdrop-blur-md
-          transition-all duration-500 ease-out
-          ${isHovered
-            ? "rounded-t-xl rounded-b-none bg-white/60 border-white/80 shadow-lg md:-translate-y-1"
-            : "rounded-xl bg-white/30 border-white/40 shadow-sm"
-          }
-        `}
+        className={`relative min-h-[210px] rounded-lg border p-5 shadow-[0_18px_60px_rgba(0,0,0,0.18)] transition-all duration-300 ${
+          isHovered
+            ? "border-[#2563EB]/40 bg-white"
+            : "border-slate-200 bg-white"
+        }`}
       >
-        {/* Icon + Title */}
-        <div className="flex items-center gap-3 mb-3">
-          <span className="text-2xl flex-shrink-0">{icon}</span>
-          <h3 className="text-lg font-bold text-gray-800 leading-tight">
-            {title}
-          </h3>
+        <div className="flex items-center gap-3">
+          <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-md border border-[#2563EB]/25 bg-[#2563EB]/10 text-2xl text-[#2563EB]">
+            {icon}
+          </span>
+          <h3 className="text-lg font-black leading-tight text-[#0B1220]">{title}</h3>
         </div>
 
-        {/* Summary line — always visible */}
-        <p className="text-sm text-gray-600 leading-relaxed">
-          {summary}
-        </p>
+        <p className="mt-4 text-sm leading-relaxed text-slate-600">{summary}</p>
 
-        {/* Subtle hover indicator */}
-        <div
-          className={`
-            absolute bottom-3 right-4 text-xs text-gray-400
-            transition-opacity duration-300
-            ${isHovered ? "opacity-0" : "opacity-100"}
-          `}
-        >
-          Hover for details
-        </div>
+        <div className="absolute bottom-4 left-5 right-5 h-px bg-slate-200" aria-hidden="true" />
       </div>
 
-      {/* Detail bullets — revealed on hover without changing desktop grid row height */}
       <div
-        className={`
-          relative z-30 w-full overflow-hidden rounded-b-xl border-x border-b
-          border-white/80 bg-white shadow-xl backdrop-blur-md
-          transition-all duration-500 ease-out
-          md:absolute md:left-0 md:right-0 md:top-[calc(100%-1px)]
-          ${isHovered
-            ? "max-h-[520px] opacity-100 translate-y-0 pointer-events-auto"
-            : "max-h-0 opacity-0 -translate-y-2 pointer-events-none"
-          }
-        `}
+        className={`relative z-30 w-full overflow-hidden rounded-b-lg border-x border-b border-[#2563EB]/20 bg-white shadow-[0_24px_70px_rgba(11,18,32,0.16)] transition-all duration-300 md:absolute md:left-0 md:right-0 md:top-[calc(100%-1px)] ${
+          isHovered
+            ? "max-h-[560px] translate-y-0 opacity-100"
+            : "max-h-0 -translate-y-2 opacity-0"
+        }`}
       >
-        <div className="mx-6 border-t border-gray-300/50 py-4">
-          <ul className="space-y-2">
-            {details.map((detail, i) => (
-              <li
-                key={i}
-                className="flex items-start gap-2 text-sm text-gray-700"
-                style={{
-                  transitionDelay: `${i * 60}ms`,
-                  opacity: isHovered ? 1 : 0,
-                  transform: isHovered ? "translateY(0)" : "translateY(8px)",
-                  transition: "opacity 400ms ease, transform 400ms ease",
-                }}
-              >
-                <span className="text-gray-400 mt-0.5 flex-shrink-0">▸</span>
-                <span className="leading-relaxed">{detail}</span>
-              </li>
-            ))}
-          </ul>
-        </div>
+        <ul className="space-y-3 p-5">
+          {details.map((detail, index) => (
+            <li key={index} className="flex gap-3 text-sm leading-relaxed text-slate-700">
+              <span className="mt-1 h-2 w-2 shrink-0 rounded-full bg-[#20A875]" />
+              <span>{detail}</span>
+            </li>
+          ))}
+        </ul>
       </div>
     </article>
   );

--- a/main/src/components/ProjectCard.jsx
+++ b/main/src/components/ProjectCard.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useId, useRef, useState } from "react";
 import { FaArrowLeft, FaGithub, FaInfoCircle } from "react-icons/fa";
+import { StackChips, StatusBadge } from "./MissionControl.jsx";
 import { trackEvent, trackLinkClick } from "../utils/analytics";
 
 function usePrefersReducedMotion() {
@@ -35,6 +36,7 @@ function ProjectCard({ id, title, techStack, bullets, github, logo }) {
   const prefersReducedMotion = usePrefersReducedMotion();
   const cardId = useId();
   const detailsId = `${cardId}-details`;
+  const stackItems = techStack.split(",").map((item) => item.trim());
   const cardTransform = prefersReducedMotion
     ? "none"
     : isFlipped
@@ -100,11 +102,11 @@ function ProjectCard({ id, title, techStack, bullets, github, logo }) {
   return (
     <article
       aria-label={`${title} project`}
-      className="w-full min-h-[27rem] perspective"
+      className="w-full min-h-[29rem] perspective"
       onKeyDown={handleKeyDown}
     >
       <div
-        className="relative min-h-[27rem] w-full transform-style-preserve-3d transition-transform duration-500 will-change-transform motion-reduce:transition-none"
+        className="relative min-h-[29rem] w-full transform-style-preserve-3d transition-transform duration-500 will-change-transform motion-reduce:transition-none"
         style={{
           WebkitTransform: cardTransform,
           WebkitTransformStyle: "preserve-3d",
@@ -114,59 +116,76 @@ function ProjectCard({ id, title, techStack, bullets, github, logo }) {
       >
         <div
           aria-hidden={isFlipped}
-          className={`absolute inset-0 flex flex-col overflow-hidden rounded-lg bg-[#FFD700] bg-opacity-60 p-6 shadow-md backface-hidden ${
+          className={`absolute inset-0 flex flex-col overflow-hidden rounded-2xl border border-[#2563EB]/25 bg-[#111827] p-5 text-white shadow-[0_22px_60px_rgba(11,18,32,0.20)] backface-hidden ${
             isFlipped ? "pointer-events-none" : ""
           }`}
           style={frontFaceStyle}
         >
-          <a
-            href={github}
-            target="_blank"
-            rel="noopener noreferrer"
-            tabIndex={isFlipped ? -1 : 0}
-            onClick={() =>
-              trackLinkClick("project_source_click", {
-                href: github,
-                label: "Source Code",
-                placement: "project_card",
-                project_id: id,
-                project_title: title,
-              })
-            }
-            className="absolute top-2 right-2 flex items-center text-gray-600 hover:text-gray-800 z-20"
-          >
-            <FaGithub className="mr-1" />
-            <span>Source Code</span>
-          </a>
-          <div className="relative z-10 flex flex-col h-full">
-            <div className="flex-shrink-0">
-              <div className="flex items-center mb-4">
-                <h2 className="text-2xl font-bold mr-2 mt-4">{title}</h2>
-              </div>
-              <p className="text-gray-600 font-bold mb-4">{techStack}</p>
+          <div className="absolute inset-x-0 top-0 h-1 bg-[#F96302]" aria-hidden="true" />
+          <div
+            className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(37,99,235,0.20),transparent_18rem)]"
+            aria-hidden="true"
+          />
+
+          <div className="relative z-10 flex items-start justify-between gap-4">
+            <div>
+              <p className="text-xs font-black uppercase tracking-[0.16em] text-[#FFB077]">
+                Build record
+              </p>
+              <h2 className="mt-2 break-words text-2xl font-black leading-tight text-white">
+                {title}
+              </h2>
             </div>
-            <div className="flex flex-1 items-center justify-center py-5">
-              <img
-                src={logo}
-                alt=""
-                aria-hidden="true"
-                className="max-h-40 max-w-[78%] object-contain"
-              />
-            </div>
+            <a
+              href={github}
+              target="_blank"
+              rel="noopener noreferrer"
+              tabIndex={isFlipped ? -1 : 0}
+              onClick={() =>
+                trackLinkClick("project_source_click", {
+                  href: github,
+                  label: "Source Code",
+                  placement: "project_card",
+                  project_id: id,
+                  project_title: title,
+                })
+              }
+              className="inline-flex shrink-0 items-center rounded-md border border-white/15 bg-white/10 px-3 py-2 text-sm font-black text-white transition hover:border-[#F96302]/60 hover:bg-white/15 focus:outline-none focus:ring-2 focus:ring-[#F96302] focus:ring-offset-2 focus:ring-offset-[#111827]"
+            >
+              <FaGithub className="mr-2" aria-hidden="true" />
+              Source Code
+            </a>
           </div>
-          <button
-            ref={detailsButtonRef}
-            type="button"
-            onClick={showDetails}
-            tabIndex={isFlipped ? -1 : 0}
-            aria-label={`Show details for ${title}`}
-            aria-expanded={isFlipped}
-            aria-controls={detailsId}
-            className="relative z-10 mt-auto inline-flex w-full items-center justify-center rounded bg-white/85 px-4 py-3 text-sm font-bold text-gray-700 shadow-sm transition-colors hover:bg-white focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 sm:w-fit sm:justify-start sm:py-2"
-          >
-            <FaInfoCircle className="mr-2" />
-            Details
-          </button>
+
+          <StackChips items={stackItems} className="relative z-10 mt-4" />
+
+          <div className="relative z-10 my-5 flex flex-1 items-center justify-center rounded-2xl border border-white/10 bg-[#E8EDF2] p-5">
+            <img
+              src={logo}
+              alt=""
+              aria-hidden="true"
+              className="max-h-36 max-w-[78%] object-contain"
+            />
+          </div>
+
+          <div className="relative z-10 mt-auto flex items-center justify-between gap-3">
+            <StatusBadge tone="cyan" className="border-white/15 bg-white/10 text-slate-100">
+              Details available
+            </StatusBadge>
+            <button
+              ref={detailsButtonRef}
+              type="button"
+              onClick={showDetails}
+              tabIndex={isFlipped ? -1 : 0}
+              aria-label={`Show details for ${title}`}
+              aria-expanded={isFlipped}
+              aria-controls={detailsId}
+              className="mc-button-light"
+            >
+              <FaInfoCircle className="mr-2" aria-hidden="true" />
+              Details
+            </button>
+          </div>
         </div>
 
         <div
@@ -174,18 +193,21 @@ function ProjectCard({ id, title, techStack, bullets, github, logo }) {
           role="region"
           aria-hidden={!isFlipped}
           aria-labelledby={`${detailsId}-heading`}
-          className={`absolute inset-0 flex flex-col overflow-hidden rounded-lg bg-[#FFD700] bg-opacity-60 p-6 shadow-md backface-hidden rotate-y-180 ${
+          className={`absolute inset-0 flex flex-col overflow-hidden rounded-lg border border-[#2563EB]/35 bg-[#0B1220] p-5 text-white shadow-[0_20px_70px_rgba(11,18,32,0.35)] backface-hidden rotate-y-180 ${
             isFlipped ? "" : "pointer-events-none"
           }`}
           style={backFaceStyle}
         >
-          <h3 id={`${detailsId}-heading`} className="text-xl font-semibold mb-4">{title} details</h3>
-          <div className="flex-grow max-h-full overflow-y-auto pr-2">
-            <ul className="list-none pl-0 space-y-2">
+          <p className="text-xs font-black uppercase text-[#93B4FF]">Technical notes</p>
+          <h3 id={`${detailsId}-heading`} className="mt-2 text-xl font-black">
+            {title} details
+          </h3>
+          <div className="mt-4 flex-grow overflow-y-auto pr-2">
+            <ul className="space-y-3">
               {bullets.map((bullet, index) => (
-                <li key={index} className="text-gray-700 flex">
-                  <span className="mr-2 flex-shrink-0">•</span>
-                  <span className="flex-1">{bullet}</span>
+                <li key={index} className="flex gap-3 text-sm leading-relaxed text-slate-200">
+                  <span className="mt-1 h-2 w-2 shrink-0 rounded-full bg-[#20A875]" />
+                  <span>{bullet}</span>
                 </li>
               ))}
             </ul>
@@ -196,9 +218,9 @@ function ProjectCard({ id, title, techStack, bullets, github, logo }) {
             onClick={hideDetails}
             tabIndex={isFlipped ? 0 : -1}
             aria-label={`Hide details for ${title}`}
-            className="mt-4 inline-flex w-full items-center justify-center rounded bg-white/85 px-4 py-3 text-sm font-bold text-gray-700 shadow-sm transition-colors hover:bg-white focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 sm:w-fit sm:justify-start sm:py-2"
+            className="mt-4 inline-flex w-full items-center justify-center rounded-md border border-white/15 bg-white/10 px-4 py-3 text-sm font-black text-white transition hover:border-[#2563EB] hover:bg-white/15 focus:outline-none focus:ring-2 focus:ring-[#2563EB] focus:ring-offset-2 focus:ring-offset-[#0B1220] sm:w-fit sm:py-2"
           >
-            <FaArrowLeft className="mr-2" />
+            <FaArrowLeft className="mr-2" aria-hidden="true" />
             Back
           </button>
         </div>
@@ -206,4 +228,5 @@ function ProjectCard({ id, title, techStack, bullets, github, logo }) {
     </article>
   );
 }
+
 export default ProjectCard;

--- a/main/src/components/SocialLinks.jsx
+++ b/main/src/components/SocialLinks.jsx
@@ -9,9 +9,9 @@ const socialIconById = {
 };
 
 const socialClassById = {
-  linkedin: "bg-blue-600 hover:bg-blue-700",
-  github: "bg-gray-800 hover:bg-gray-900",
-  email: "bg-gray-800 hover:bg-gray-900",
+  linkedin: "border-[#2563EB]/30 bg-[#2563EB]/10 text-[#1d4ed8] hover:bg-[#2563EB]/15",
+  github: "border-slate-300 bg-white text-[#0B1220] hover:bg-[#E8EDF2]",
+  email: "border-[#F96302]/30 bg-[#F96302]/10 text-[#b94600] hover:bg-[#F96302]/15",
 };
 
 function SocialLinks({
@@ -37,9 +37,9 @@ function SocialLinks({
                 social_platform: link.id,
               })
             }
-            className={`${socialClassById[link.id]} text-white font-bold py-2 px-4 rounded inline-flex items-center`}
+            className={`${socialClassById[link.id]} inline-flex items-center rounded-md border px-3 py-2 text-sm font-black transition focus:outline-none focus:ring-2 focus:ring-[#2563EB] focus:ring-offset-2`}
           >
-            <Icon className="mr-2" />
+            <Icon className="mr-2" aria-hidden="true" />
             {link.label}
           </a>
         );

--- a/main/src/components/SocialLinks.jsx
+++ b/main/src/components/SocialLinks.jsx
@@ -8,6 +8,19 @@ const socialIconById = {
   email: FaEnvelope,
 };
 
+const socialClassBySurface = {
+  light: {
+    linkedin: "border-[#2563EB]/30 bg-[#2563EB]/10 text-[#1d4ed8] hover:bg-[#2563EB]/15",
+    github: "border-slate-300 bg-white text-[#0B1220] hover:bg-[#E8EDF2]",
+    email: "border-[#F96302]/30 bg-[#F96302]/10 text-[#b94600] hover:bg-[#F96302]/15",
+  },
+  dark: {
+    linkedin: "border-[#2563EB]/35 bg-[#2563EB]/15 text-[#93B4FF] hover:bg-[#2563EB]/25",
+    github: "border-white/15 bg-white/10 text-white hover:border-white/25 hover:bg-white/15",
+    email: "border-[#F96302]/35 bg-[#F96302]/15 text-[#FFB077] hover:bg-[#F96302]/25",
+  },
+};
+
 const socialClassById = {
   linkedin: "border-[#2563EB]/30 bg-[#2563EB]/10 text-[#1d4ed8] hover:bg-[#2563EB]/15",
   github: "border-slate-300 bg-white text-[#0B1220] hover:bg-[#E8EDF2]",
@@ -17,11 +30,18 @@ const socialClassById = {
 function SocialLinks({
   className = "flex flex-wrap justify-center gap-3",
   placement = "social_links",
+  surface = "light",
 }) {
+  const surfaceClasses = socialClassBySurface[surface] ?? socialClassBySurface.light;
+  const focusOffsetClass = surface === "dark"
+    ? "focus:ring-offset-[#0B1220]"
+    : "focus:ring-offset-white";
+
   return (
     <div className={className}>
       {socialLinks.map((link) => {
         const Icon = socialIconById[link.id];
+        const socialClass = surfaceClasses[link.id] ?? socialClassById[link.id];
         return (
           <a
             key={link.id}
@@ -37,7 +57,7 @@ function SocialLinks({
                 social_platform: link.id,
               })
             }
-            className={`${socialClassById[link.id]} inline-flex items-center rounded-md border px-3 py-2 text-sm font-black transition focus:outline-none focus:ring-2 focus:ring-[#2563EB] focus:ring-offset-2`}
+            className={`${socialClass} ${focusOffsetClass} inline-flex items-center rounded-md border px-3 py-2 text-sm font-black transition focus:outline-none focus:ring-2 focus:ring-[#2563EB] focus:ring-offset-2`}
           >
             <Icon className="mr-2" aria-hidden="true" />
             {link.label}

--- a/main/src/data/experience.js
+++ b/main/src/data/experience.js
@@ -35,7 +35,6 @@ export const workExperiences = [
       "Improved operational responsiveness by decreasing alert acknowledgement times 30% via optimizing tiered alerting and Grafana dashboards across 20+ microservices, automating escalation via Slack and PagerDuty integrations.",
     ],
     logo: hdLogo,
-    color: "bg-[#FFA500]",
   },
   {
     id: "home-depot-intern-2024",
@@ -48,7 +47,6 @@ export const workExperiences = [
       "Leveraged Java to obtain germane product data, used React and TypeScript to effectively display product information for all registers at self-checkout, pruning customer theft by \u223c$10 million annually.",
     ],
     logo: hdLogo,
-    color: "bg-[#FFA500]",
   },
   {
     id: "home-depot-intern-2023",
@@ -62,7 +60,6 @@ export const workExperiences = [
       "Collaborated with cross-functional teams, including the UI/UX team, designing and constructing user interface components for a new configuration process - utilizing React, Next.js, and TypeScript.",
     ],
     logo: hdLogo,
-    color: "bg-[#FFA500]",
   },
   {
     id: "landis-gyr-firmware-intern",
@@ -75,7 +72,6 @@ export const workExperiences = [
       "Bolstered data transmission efficiency by \u223c25%, collaborating with a software architect to conduct comprehensive testing of collectors and debugging of various Python scripts employing MySQL.",
     ],
     logo: landisGyrLogo,
-    color: "bg-white bg-opacity-100",
   },
 ]
 
@@ -143,7 +139,6 @@ export const extracurricularExperiences = [
       "Leveraged an inbuilt API for image recognition, identifying and ranking the top 3 product matches for shopping carts.",
     ],
     logo: fintechGTLogo,
-    color: "bg-[#FFD700] bg-opacity-70",
   },
   {
     id: "cdc-project-manager-full-stack-developer",
@@ -161,7 +156,6 @@ export const extracurricularExperiences = [
       "Constructed technical diagrams/documentation (Lo-Fi & Hi-Fi Prototypes, User Research, Minimum Marketable Features, Story Mapping, UX Report, and Detailed Design) to aid the development process.",
     ],
     logo: cdcLogo,
-    color: "bg-white bg-opacity-100",
   },
   {
     id: "gt-undergraduate-teaching-assistant",
@@ -175,6 +169,5 @@ export const extracurricularExperiences = [
       "Fostered engagement by answering 105+ questions on Piazza, the student discussion forum.",
     ],
     logo: gtComputingLogo,
-    color: "bg-[#FFD700] bg-opacity-70",
   },
 ]

--- a/main/src/index.css
+++ b/main/src/index.css
@@ -1,3 +1,251 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  :root {
+    color-scheme: light;
+    background: #f4f1ea;
+  }
+
+  html {
+    scroll-behavior: smooth;
+  }
+
+  body {
+    margin: 0;
+    background: #f4f1ea;
+    color: #0b1220;
+    font-family:
+      Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+      sans-serif;
+  }
+
+  * {
+    min-width: 0;
+  }
+}
+
+@layer components {
+  .mc-page {
+    position: relative;
+    min-height: calc(100dvh - 3.5rem);
+    overflow: hidden;
+    background-color: #f4f1ea;
+    background-image:
+      radial-gradient(circle at top left, rgba(37, 99, 235, 0.11), transparent 28rem),
+      linear-gradient(180deg, #f4f1ea 0%, #f7f5ef 48%, #e8edf2 100%);
+  }
+
+  .mc-panel {
+    @apply rounded-lg border border-slate-200 bg-white text-[#0B1220] shadow-[0_18px_50px_rgba(11,18,32,0.10)];
+  }
+
+  .mc-panel-dark {
+    @apply rounded-lg border border-white/10 bg-[#0B1220] text-white shadow-[0_24px_70px_rgba(11,18,32,0.28)];
+  }
+
+  .mc-presentation-panel {
+    position: relative;
+    overflow: hidden;
+    border-radius: 2rem;
+    border: 1px solid rgba(148, 163, 184, 0.24);
+    background-color: #0b1220;
+    background-image:
+      linear-gradient(135deg, rgba(249, 99, 2, 0.12), transparent 28%),
+      linear-gradient(145deg, rgba(37, 99, 235, 0.16), transparent 46%),
+      radial-gradient(circle at 86% 18%, rgba(32, 168, 117, 0.13), transparent 24rem),
+      linear-gradient(180deg, rgba(255, 255, 255, 0.055), rgba(255, 255, 255, 0.015));
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.08),
+      0 32px 90px rgba(11, 18, 32, 0.32);
+  }
+
+  .mc-presentation-panel::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background-image:
+      linear-gradient(rgba(147, 180, 255, 0.045) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(147, 180, 255, 0.045) 1px, transparent 1px);
+    background-size: 42px 42px;
+    mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.55), transparent 76%);
+  }
+
+  .mc-signal-card {
+    @apply rounded-2xl border border-white/10 bg-white/[0.065] p-5 shadow-[inset_0_1px_0_rgba(255,255,255,0.06),0_18px_42px_rgba(0,0,0,0.18)];
+  }
+
+  .mc-system-diagram {
+    position: relative;
+    overflow: hidden;
+    border-radius: 1.5rem;
+    border: 1px solid rgba(148, 163, 184, 0.22);
+    background-color: #030712;
+    background-image:
+      radial-gradient(circle at center, rgba(249, 99, 2, 0.16), transparent 12rem),
+      radial-gradient(circle at 20% 30%, rgba(37, 99, 235, 0.22), transparent 14rem),
+      radial-gradient(circle at 76% 74%, rgba(124, 58, 237, 0.18), transparent 14rem),
+      linear-gradient(rgba(37, 99, 235, 0.08) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(37, 99, 235, 0.08) 1px, transparent 1px);
+    background-size: auto, auto, auto, 28px 28px, 28px 28px;
+    padding: 1rem;
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.08),
+      inset 0 0 42px rgba(37, 99, 235, 0.12);
+  }
+
+  .mc-system-diagram::before {
+    content: "";
+    position: absolute;
+    inset: 0.75rem;
+    pointer-events: none;
+    border-radius: 1.125rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+  }
+
+  .mc-system-hub {
+    @apply rounded-2xl border border-[#F96302]/70 bg-[#0B1220]/90 p-4 text-center shadow-[0_0_0_1px_rgba(249,99,2,0.16),0_0_36px_rgba(249,99,2,0.42),inset_0_0_24px_rgba(249,99,2,0.10)];
+  }
+
+  .mc-system-link {
+    position: absolute;
+    height: 2px;
+    border-radius: 999px;
+    background: linear-gradient(90deg, transparent, #f96302 20%, #ffb077 50%, #f96302 80%, transparent);
+    box-shadow: 0 0 18px rgba(249, 99, 2, 0.72);
+    transform-origin: center;
+  }
+
+  .mc-system-node {
+    @apply rounded-2xl border bg-[#07111f]/90 p-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.06),0_16px_36px_rgba(0,0,0,0.28)];
+  }
+
+  .mc-system-node-blue {
+    @apply border-[#3B82F6]/55 text-[#60A5FA] shadow-[0_0_24px_rgba(37,99,235,0.24),inset_0_1px_0_rgba(255,255,255,0.06)];
+  }
+
+  .mc-system-node-green {
+    @apply border-[#20A875]/55 text-[#4ADE80] shadow-[0_0_24px_rgba(32,168,117,0.20),inset_0_1px_0_rgba(255,255,255,0.06)];
+  }
+
+  .mc-system-node-orange {
+    @apply border-[#F96302]/65 text-[#FFB077] shadow-[0_0_26px_rgba(249,99,2,0.28),inset_0_1px_0_rgba(255,255,255,0.06)];
+  }
+
+  .mc-system-node-purple {
+    @apply border-violet-400/55 text-violet-300 shadow-[0_0_24px_rgba(124,58,237,0.24),inset_0_1px_0_rgba(255,255,255,0.06)];
+  }
+
+  .mc-eyebrow {
+    @apply mb-3 text-xs font-black uppercase text-[#2563EB];
+  }
+
+  .mc-button-primary {
+    @apply inline-flex items-center justify-center rounded-md bg-[#F96302] px-4 py-2 text-sm font-black text-white shadow-[0_14px_34px_rgba(249,99,2,0.22)] transition hover:bg-[#d95402] focus:outline-none focus:ring-2 focus:ring-[#F96302] focus:ring-offset-2 focus:ring-offset-[#0B1220];
+  }
+
+  .mc-button-secondary {
+    @apply inline-flex items-center justify-center rounded-md border border-[#2563EB]/35 bg-white/10 px-4 py-2 text-sm font-black text-white transition hover:border-[#2563EB] hover:bg-white/15 focus:outline-none focus:ring-2 focus:ring-[#2563EB] focus:ring-offset-2 focus:ring-offset-[#0B1220];
+  }
+
+  .mc-button-light {
+    @apply inline-flex items-center justify-center rounded-md bg-[#0B1220] px-4 py-2 text-sm font-black text-white transition hover:bg-[#172033] focus:outline-none focus:ring-2 focus:ring-[#2563EB] focus:ring-offset-2;
+  }
+
+  .mc-chip {
+    @apply rounded-full border border-slate-300 bg-[#E8EDF2] px-3 py-1 text-xs font-bold text-slate-700;
+  }
+
+  .mc-field {
+    @apply w-full rounded-md border border-white/15 bg-[#0B1220]/80 px-3 py-2 text-white shadow-inner outline-none transition placeholder:text-slate-500 focus:border-[#F96302] focus:ring-2 focus:ring-[#F96302]/25;
+  }
+
+  .mc-dark-field {
+    background-color: #0b1220;
+    background-image:
+      linear-gradient(rgba(37, 99, 235, 0.07) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(37, 99, 235, 0.07) 1px, transparent 1px),
+      radial-gradient(circle at 15% 5%, rgba(249, 99, 2, 0.2), transparent 24rem),
+      radial-gradient(circle at 85% 20%, rgba(37, 99, 235, 0.22), transparent 26rem);
+    background-size: 48px 48px, 48px 48px, auto, auto;
+  }
+
+  .mc-blue-section {
+    background:
+      linear-gradient(135deg, rgba(37, 99, 235, 0.25), transparent 38%),
+      #10254a;
+  }
+
+  .mc-impact-band {
+    @apply grid overflow-hidden rounded-lg border border-slate-200 bg-white px-5 py-3 text-[#0B1220] shadow-[0_18px_50px_rgba(11,18,32,0.08)] sm:grid-cols-2 lg:grid-cols-4;
+  }
+
+  .mc-impact-band-dark {
+    @apply border-white/10 bg-white/5 text-white shadow-none;
+  }
+
+  .mc-impact-value {
+    @apply text-4xl font-black leading-none text-[#0B1220] sm:text-5xl;
+  }
+
+  .mc-impact-band-dark .mc-impact-value {
+    @apply text-white;
+  }
+
+  .mc-impact-value-orange {
+    @apply text-4xl font-black leading-none text-[#F96302] sm:text-5xl;
+  }
+
+  .mc-impact-band-compact .mc-impact-value,
+  .mc-impact-band-compact .mc-impact-value-orange {
+    @apply text-3xl sm:text-4xl;
+  }
+}
+
+@keyframes mc-panel-rise {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes mc-line-reveal {
+  from {
+    transform: scaleX(0);
+  }
+  to {
+    transform: scaleX(1);
+  }
+}
+
+.mc-rise {
+  animation: mc-panel-rise 560ms ease-out both;
+}
+
+.mc-line-reveal {
+  transform-origin: left;
+  animation: mc-line-reveal 720ms ease-out both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  .mc-rise,
+  .mc-line-reveal {
+    animation: none;
+  }
+
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+  }
+}

--- a/main/src/pages/CaseStudies.jsx
+++ b/main/src/pages/CaseStudies.jsx
@@ -1,115 +1,158 @@
-import React from "react"
-import { Link } from "react-router-dom"
-import { FaArrowRight, FaChartLine } from "react-icons/fa"
-import { caseStudies, caseStudiesPage } from "../data/caseStudies"
-import { trackEvent } from "../utils/analytics"
+import React from "react";
+import { Link } from "react-router-dom";
+import { FaArrowRight, FaChartLine, FaCodeBranch, FaServer } from "react-icons/fa";
+import {
+  ImpactBand,
+  PageContainer,
+  PageShell,
+  SectionHeader,
+  StatusBadge,
+  SystemDiagram,
+} from "../components/MissionControl.jsx";
+import { caseStudies, caseStudiesPage } from "../data/caseStudies";
+import { trackEvent } from "../utils/analytics";
 
 const logoFrameClassByTheme = {
-  "home-depot": "border-orange-500 bg-[#F96302]",
-  cdc: "border-gray-200 bg-white",
+  "home-depot": "border-[#F96302] bg-[#F96302]",
+  cdc: "border-slate-200 bg-white",
+};
+
+const flowIcons = [FaServer, FaCodeBranch, FaChartLine];
+
+function buildCaseStudyNodes(caseStudy) {
+  const flowNodes = caseStudy.flow.map((step, index) => ({
+    label: step.title,
+    detail: `Step ${index + 1}`,
+    tone: index === 1 ? "orange" : "blue",
+    icon: flowIcons[index] ?? FaCodeBranch,
+  }));
+  const metricNodes = caseStudy.metrics.slice(0, 3).map((metric, index) => ({
+    label: metric.value,
+    detail: metric.label,
+    tone: index === 1 ? "orange" : index === 2 ? "green" : "purple",
+    icon: index === 0 ? FaChartLine : FaArrowRight,
+  }));
+
+  return [...flowNodes, ...metricNodes];
+}
+
+function CaseStudyCard({ caseStudy, featured = false }) {
+  const cardClass = featured
+    ? "mc-presentation-panel p-5 text-white sm:p-7 lg:grid lg:grid-cols-[minmax(0,1fr)_minmax(22rem,0.92fr)] lg:gap-8"
+    : "mc-panel flex min-h-[28rem] flex-col p-5";
+  const mutedText = featured ? "text-slate-300" : "text-slate-600";
+  const titleText = featured ? "text-white" : "text-[#0B1220]";
+  const metaText = featured ? "text-slate-400" : "text-slate-500";
+
+  return (
+    <article className={cardClass}>
+      <div className={featured ? "relative z-10" : "flex flex-1 flex-col"}>
+        <div className="mb-5 flex items-start justify-between gap-4">
+          <div>
+            <StatusBadge tone={caseStudy.logoTheme === "home-depot" ? "orange" : "cyan"}>
+              {caseStudy.category}
+            </StatusBadge>
+            <p className={`mt-3 text-sm font-bold ${metaText}`}>
+              {caseStudy.organization} / {caseStudy.timeframe}
+            </p>
+          </div>
+          <span
+            className={`flex h-14 w-14 shrink-0 items-center justify-center rounded-md border p-1 ${logoFrameClassByTheme[caseStudy.logoTheme]}`}
+          >
+            <img
+              src={caseStudy.logo}
+              alt=""
+              aria-hidden="true"
+              className="max-h-full max-w-full object-contain"
+            />
+          </span>
+        </div>
+
+        <h2 className={`text-3xl font-black leading-tight ${titleText}`}>
+          {caseStudy.title}
+        </h2>
+        <p className={`mt-4 ${featured ? "max-w-3xl text-lg" : "text-sm"} flex-1 leading-relaxed ${mutedText}`}>
+          {caseStudy.summary}
+        </p>
+
+        <Link
+          to={`/case-studies/${caseStudy.slug}`}
+          onClick={() =>
+            trackEvent("case_study_card_click", {
+              case_study_slug: caseStudy.slug,
+              case_study_title: caseStudy.title,
+              placement: "case_studies_grid",
+            })
+          }
+          className={featured ? "mc-button-primary mt-6 w-fit" : "mc-button-light mt-5 w-fit"}
+        >
+          Read case study
+          <FaArrowRight className="ml-2" aria-hidden="true" />
+        </Link>
+      </div>
+
+      <div className={featured ? "relative z-10 mt-6 lg:mt-0" : "mt-5 grid gap-2"}>
+        {featured ? (
+          <SystemDiagram
+            centerLabel={caseStudy.category}
+            centerDetail={caseStudy.organization}
+            nodes={buildCaseStudyNodes(caseStudy)}
+            caption="Each case study keeps the problem, rollout path, and measured outcome connected for quick inspection."
+          />
+        ) : (
+          caseStudy.metrics.slice(0, 2).map((metric) => (
+            <div
+              key={metric.label}
+              className="rounded-md border border-slate-200 bg-[#E8EDF2] px-3 py-2"
+            >
+              <p className="text-2xl font-black text-[#0B1220]">
+                {metric.value}
+              </p>
+              <p className="text-sm font-bold text-slate-600">
+                {metric.label}
+              </p>
+            </div>
+          ))
+        )}
+      </div>
+    </article>
+  );
 }
 
 function CaseStudies() {
-  return (
-    <main className="min-h-screen bg-blue-100 px-4 py-8 font-cambria">
-      <div className="mx-auto max-w-6xl">
-        <header className="mb-8 grid gap-6 md:grid-cols-[minmax(0,1fr)_minmax(18rem,24rem)] md:items-end">
-          <div className="relative pl-5">
-            <span className="absolute left-0 top-1 h-[calc(100%-0.5rem)] w-1 rounded bg-blue-800" />
-            <p className="mb-2 text-sm font-bold uppercase tracking-wide text-blue-800">
-              Case Studies
-            </p>
-            <h1 className="max-w-4xl text-4xl font-bold leading-tight text-gray-900 sm:text-5xl">
-              {caseStudiesPage.title}
-            </h1>
-            <p className="mt-4 max-w-3xl text-lg leading-relaxed text-gray-700">
-              {caseStudiesPage.description}
-            </p>
-          </div>
+  const [featuredCaseStudy, ...supportingCaseStudies] = caseStudies;
 
-          <div className="grid gap-3">
-            {caseStudiesPage.stats.map((stat) => (
-              <div
-                key={stat.id}
-                className="rounded-lg border border-blue-200 bg-white/70 px-4 py-3 shadow-sm"
-              >
-                <p className="text-2xl font-bold text-blue-900">{stat.value}</p>
-                <p className="text-sm leading-snug text-gray-700">{stat.label}</p>
-              </div>
+  return (
+    <PageShell>
+      <PageContainer className="space-y-10">
+        <SectionHeader
+          eyebrow="Case-study library"
+          title={caseStudiesPage.title}
+          description={caseStudiesPage.description}
+        />
+
+        <ImpactBand
+          items={caseStudiesPage.stats.map((stat, index) => ({
+            value: stat.value,
+            label: stat.label,
+            tone: index === 2 ? "orange" : undefined,
+          }))}
+        />
+
+        <section className="space-y-6" aria-label="Case studies">
+          {featuredCaseStudy ? (
+            <CaseStudyCard caseStudy={featuredCaseStudy} featured />
+          ) : null}
+
+          <div className="grid gap-5 lg:grid-cols-2">
+            {supportingCaseStudies.map((caseStudy) => (
+              <CaseStudyCard key={caseStudy.slug} caseStudy={caseStudy} />
             ))}
           </div>
-        </header>
-
-        <section className="grid gap-5 md:grid-cols-3" aria-label="Case studies">
-          {caseStudies.map((caseStudy) => (
-            <article
-              key={caseStudy.slug}
-              className="flex min-h-[26rem] flex-col rounded-lg border border-blue-200 bg-white p-5 shadow-sm"
-            >
-              <div className="mb-4 flex items-start justify-between gap-4">
-                <div>
-                  <p className="text-xs font-bold uppercase tracking-wide text-blue-700">
-                    {caseStudy.category}
-                  </p>
-                  <p className="mt-1 text-sm text-gray-600">
-                    {caseStudy.organization} {"\u00b7"} {caseStudy.timeframe}
-                  </p>
-                </div>
-                <span
-                  className={`flex h-14 w-14 flex-shrink-0 items-center justify-center rounded border p-1 ${logoFrameClassByTheme[caseStudy.logoTheme]}`}
-                >
-                  <img
-                    src={caseStudy.logo}
-                    alt=""
-                    aria-hidden="true"
-                    className="max-h-full max-w-full object-contain"
-                  />
-                </span>
-              </div>
-
-              <h2 className="text-xl font-bold leading-snug text-gray-900">
-                {caseStudy.title}
-              </h2>
-              <p className="mt-3 flex-1 text-sm leading-relaxed text-gray-700">
-                {caseStudy.summary}
-              </p>
-
-              <div className="mt-4 grid gap-2">
-                {caseStudy.metrics.slice(0, 2).map((metric) => (
-                  <div
-                    key={metric.label}
-                    className="flex items-center gap-3 rounded border border-gray-200 bg-blue-50 px-3 py-2"
-                  >
-                    <FaChartLine className="text-blue-700" aria-hidden="true" />
-                    <div>
-                      <p className="text-sm font-bold text-gray-900">
-                        {metric.value} {metric.label}
-                      </p>
-                    </div>
-                  </div>
-                ))}
-              </div>
-
-              <Link
-                to={`/case-studies/${caseStudy.slug}`}
-                onClick={() =>
-                  trackEvent("case_study_card_click", {
-                    case_study_slug: caseStudy.slug,
-                    case_study_title: caseStudy.title,
-                    placement: "case_studies_grid",
-                  })
-                }
-                className="mt-5 inline-flex w-fit items-center rounded bg-blue-700 px-4 py-2 text-sm font-bold text-white transition-colors hover:bg-blue-800 focus:outline-none focus:ring-2 focus:ring-blue-900 focus:ring-offset-2"
-              >
-                Read case study
-                <FaArrowRight className="ml-2" aria-hidden="true" />
-              </Link>
-            </article>
-          ))}
         </section>
-      </div>
-    </main>
-  )
+      </PageContainer>
+    </PageShell>
+  );
 }
 
-export default CaseStudies
+export default CaseStudies;

--- a/main/src/pages/CaseStudies.jsx
+++ b/main/src/pages/CaseStudies.jsx
@@ -39,14 +39,14 @@ function buildCaseStudyNodes(caseStudy) {
 function CaseStudyCard({ caseStudy, featured = false }) {
   const cardClass = featured
     ? "mc-presentation-panel p-5 text-white sm:p-7 lg:grid lg:grid-cols-[minmax(0,1fr)_minmax(22rem,0.92fr)] lg:gap-8"
-    : "mc-panel flex min-h-[28rem] flex-col p-5";
-  const mutedText = featured ? "text-slate-300" : "text-slate-600";
-  const titleText = featured ? "text-white" : "text-[#0B1220]";
-  const metaText = featured ? "text-slate-400" : "text-slate-500";
+    : "mc-presentation-panel flex min-h-[28rem] flex-col p-5 text-white";
+  const mutedText = "text-slate-300";
+  const titleText = "text-white";
+  const metaText = "text-slate-400";
 
   return (
     <article className={cardClass}>
-      <div className={featured ? "relative z-10" : "flex flex-1 flex-col"}>
+      <div className={featured ? "relative z-10" : "relative z-10 flex flex-1 flex-col"}>
         <div className="mb-5 flex items-start justify-between gap-4">
           <div>
             <StatusBadge tone={caseStudy.logoTheme === "home-depot" ? "orange" : "cyan"}>
@@ -84,14 +84,14 @@ function CaseStudyCard({ caseStudy, featured = false }) {
               placement: "case_studies_grid",
             })
           }
-          className={featured ? "mc-button-primary mt-6 w-fit" : "mc-button-light mt-5 w-fit"}
+          className={featured ? "mc-button-primary mt-6 w-fit" : "mc-button-secondary mt-5 w-fit"}
         >
           Read case study
           <FaArrowRight className="ml-2" aria-hidden="true" />
         </Link>
       </div>
 
-      <div className={featured ? "relative z-10 mt-6 lg:mt-0" : "mt-5 grid gap-2"}>
+      <div className={featured ? "relative z-10 mt-6 lg:mt-0" : "relative z-10 mt-5 grid gap-2"}>
         {featured ? (
           <SystemDiagram
             centerLabel={caseStudy.category}
@@ -103,12 +103,12 @@ function CaseStudyCard({ caseStudy, featured = false }) {
           caseStudy.metrics.slice(0, 2).map((metric) => (
             <div
               key={metric.label}
-              className="rounded-md border border-slate-200 bg-[#E8EDF2] px-3 py-2"
+              className="rounded-md border border-white/10 bg-white/[0.065] px-3 py-2 shadow-[inset_0_1px_0_rgba(255,255,255,0.06)]"
             >
-              <p className="text-2xl font-black text-[#0B1220]">
+              <p className="text-2xl font-black text-[#93B4FF]">
                 {metric.value}
               </p>
-              <p className="text-sm font-bold text-slate-600">
+              <p className="text-sm font-bold text-slate-300">
                 {metric.label}
               </p>
             </div>

--- a/main/src/pages/CaseStudy.jsx
+++ b/main/src/pages/CaseStudy.jsx
@@ -1,107 +1,140 @@
-import React from "react"
-import { Link, useParams } from "react-router-dom"
-import { FaArrowLeft, FaArrowRight, FaExternalLinkAlt } from "react-icons/fa"
-import { getCaseStudyBySlug } from "../data/caseStudies"
-import { trackLinkClick } from "../utils/analytics"
-import NotFound from "./NotFound"
+import React from "react";
+import { Link, useParams } from "react-router-dom";
+import {
+  FaArrowLeft,
+  FaArrowRight,
+  FaChartLine,
+  FaCodeBranch,
+  FaExternalLinkAlt,
+  FaServer,
+} from "react-icons/fa";
+import {
+  ImpactBand,
+  PageContainer,
+  PageShell,
+  PresentationPanel,
+  StackChips,
+  StatusBadge,
+  SystemDiagram,
+} from "../components/MissionControl.jsx";
+import { getCaseStudyBySlug } from "../data/caseStudies";
+import { trackLinkClick } from "../utils/analytics";
+import NotFound from "./NotFound";
 
 const logoFrameClassByTheme = {
-  "home-depot": "border-orange-500 bg-[#F96302]",
-  cdc: "border-gray-200 bg-white",
+  "home-depot": "border-[#F96302] bg-[#F96302]",
+  cdc: "border-slate-200 bg-white",
+};
+
+const detailFlowIcons = [FaServer, FaCodeBranch, FaChartLine];
+
+function buildDetailNodes(caseStudy) {
+  const flowNodes = caseStudy.flow.map((step, index) => ({
+    label: step.title,
+    detail: `Step ${index + 1}`,
+    tone: index === 1 ? "orange" : "blue",
+    icon: detailFlowIcons[index] ?? FaCodeBranch,
+  }));
+  const metricNodes = caseStudy.metrics.slice(0, 3).map((metric, index) => ({
+    label: metric.value,
+    detail: metric.label,
+    tone: index === 1 ? "orange" : index === 2 ? "green" : "purple",
+    icon: index === 0 ? FaChartLine : FaArrowRight,
+  }));
+
+  return [...flowNodes, ...metricNodes];
 }
 
 function CaseStudy() {
-  const { slug } = useParams()
-  const caseStudy = getCaseStudyBySlug(slug)
+  const { slug } = useParams();
+  const caseStudy = getCaseStudyBySlug(slug);
 
   if (!caseStudy) {
-    return <NotFound />
+    return <NotFound />;
   }
 
   return (
-    <main className="min-h-screen bg-blue-100 px-4 py-6 font-cambria">
-      <article className="mx-auto max-w-6xl">
+    <PageShell>
+      <PageContainer>
         <Link
           to="/case-studies"
-          className="mb-5 inline-flex items-center rounded px-1 py-1 text-sm font-bold text-blue-800 transition-colors hover:text-blue-950 focus:outline-none focus:ring-2 focus:ring-blue-900 focus:ring-offset-2"
+          className="mb-5 inline-flex items-center rounded-md border border-slate-300 bg-white px-3 py-2 text-sm font-black text-[#0B1220] transition hover:border-[#2563EB]/50 hover:bg-[#E8EDF2] focus:outline-none focus:ring-2 focus:ring-[#2563EB] focus:ring-offset-2"
         >
           <FaArrowLeft className="mr-2" aria-hidden="true" />
           Case Studies
         </Link>
 
-        <header className="rounded-lg border border-blue-200 bg-white p-5 shadow-sm md:p-7">
-          <div className="grid gap-6 md:grid-cols-[minmax(0,1fr)_auto] md:items-start">
+        <PresentationPanel as="header" className="p-5 text-white sm:p-7">
+          <div className="relative z-10 grid gap-7 lg:grid-cols-[minmax(0,0.95fr)_minmax(22rem,1.05fr)] lg:items-start">
             <div>
-              <p className="text-sm font-bold uppercase tracking-wide text-blue-700">
+              <StatusBadge tone={caseStudy.logoTheme === "home-depot" ? "orange" : "cyan"}>
                 {caseStudy.category}
-              </p>
-              <h1 className="mt-2 max-w-4xl text-4xl font-bold leading-tight text-gray-900 sm:text-5xl">
+              </StatusBadge>
+              <h1 className="mt-5 max-w-4xl text-4xl font-black leading-tight text-white sm:text-5xl">
                 {caseStudy.title}
               </h1>
-              <p className="mt-3 text-base font-bold text-gray-600">
-                {caseStudy.organization} {"\u00b7"} {caseStudy.timeframe}
+              <p className="mt-3 text-base font-bold text-[#93B4FF]">
+                {caseStudy.organization} / {caseStudy.timeframe}
               </p>
-              <p className="mt-5 max-w-3xl text-lg leading-relaxed text-gray-700">
+              <p className="mt-5 max-w-3xl text-lg leading-relaxed text-slate-300">
                 {caseStudy.summary}
               </p>
             </div>
 
-            <span
-              className={`flex h-24 w-24 flex-shrink-0 items-center justify-center rounded border p-2 ${logoFrameClassByTheme[caseStudy.logoTheme]}`}
-            >
-              <img
-                src={caseStudy.logo}
-                alt=""
-                aria-hidden="true"
-                className="max-h-full max-w-full object-contain"
+            <div className="grid gap-4">
+              <span
+                className={`flex h-24 w-24 shrink-0 items-center justify-center rounded-2xl border p-2 ${logoFrameClassByTheme[caseStudy.logoTheme]}`}
+              >
+                <img
+                  src={caseStudy.logo}
+                  alt=""
+                  aria-hidden="true"
+                  className="max-h-full max-w-full object-contain"
+                />
+              </span>
+              <SystemDiagram
+                centerLabel={caseStudy.category}
+                centerDetail={caseStudy.organization}
+                nodes={buildDetailNodes(caseStudy)}
+                caption="The writeup keeps system context, rollout path, and measured evidence in the same frame."
               />
-            </span>
+            </div>
           </div>
-        </header>
+        </PresentationPanel>
 
         <section
           aria-labelledby="case-study-metrics"
-          className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-4"
+          className="mt-5"
         >
           <h2 id="case-study-metrics" className="sr-only">
             Case study metrics
           </h2>
-          {caseStudy.metrics.map((metric) => (
-            <div
-              key={metric.label}
-              className="rounded-lg border border-blue-200 bg-white p-4 shadow-sm"
-            >
-              <p className="text-3xl font-bold text-blue-900">{metric.value}</p>
-              <p className="mt-1 font-bold text-gray-800">{metric.label}</p>
-              <p className="mt-2 text-sm leading-relaxed text-gray-600">
-                {metric.detail}
-              </p>
-            </div>
-          ))}
+          <ImpactBand
+            items={caseStudy.metrics.map((metric, index) => ({
+              value: metric.value,
+              label: metric.label,
+              detail: metric.detail,
+              tone: index === 1 ? "orange" : undefined,
+            }))}
+          />
         </section>
 
         <div className="mt-6 grid gap-6 lg:grid-cols-[minmax(0,1fr)_18rem]">
           <div className="space-y-6">
-            <section
-              aria-labelledby="case-study-flow"
-              className="rounded-lg border border-blue-200 bg-white p-5 shadow-sm"
-            >
-              <h2 id="case-study-flow" className="text-2xl font-bold text-gray-900">
+            <section aria-labelledby="case-study-flow" className="mc-panel p-5">
+              <h2 id="case-study-flow" className="text-2xl font-black text-[#0B1220]">
                 Engineering path
               </h2>
-              <div className="mt-4 grid gap-3 md:grid-cols-3">
+              <div className="mt-5 grid gap-4 md:grid-cols-3">
                 {caseStudy.flow.map((step, index) => (
-                  <div
-                    key={step.title}
-                    className="rounded border border-gray-200 bg-blue-50 p-4"
-                  >
-                    <p className="text-sm font-bold uppercase tracking-wide text-blue-700">
+                  <div key={step.title} className="rounded-lg border border-slate-200 bg-[#E8EDF2] p-4">
+                    <p className="text-xs font-black uppercase text-[#2563EB]">
                       Step {index + 1}
                     </p>
-                    <h3 className="mt-2 text-lg font-bold text-gray-900">
+                    <h3 className="mt-3 text-lg font-black text-[#0B1220]">
                       {step.title}
                     </h3>
-                    <p className="mt-2 text-sm leading-relaxed text-gray-700">
+                    <p className="mt-3 text-sm leading-relaxed text-slate-600">
                       {step.detail}
                     </p>
                   </div>
@@ -110,14 +143,9 @@ function CaseStudy() {
             </section>
 
             {caseStudy.sections.map((section) => (
-              <section
-                key={section.heading}
-                className="rounded-lg border border-blue-200 bg-white p-5 shadow-sm"
-              >
-                <h2 className="text-2xl font-bold text-gray-900">
-                  {section.heading}
-                </h2>
-                <div className="mt-3 space-y-3 text-base leading-relaxed text-gray-700">
+              <section key={section.heading} className="mc-panel p-5">
+                <h2 className="text-2xl font-black text-[#0B1220]">{section.heading}</h2>
+                <div className="mt-4 space-y-3 text-base leading-relaxed text-slate-700">
                   {section.paragraphs.map((paragraph) => (
                     <p key={paragraph}>{paragraph}</p>
                   ))}
@@ -126,21 +154,12 @@ function CaseStudy() {
             ))}
           </div>
 
-          <aside className="h-fit rounded-lg border border-blue-200 bg-white p-5 shadow-sm">
-            <h2 className="text-xl font-bold text-gray-900">Stack</h2>
-            <div className="mt-3 flex flex-wrap gap-2">
-              {caseStudy.stack.map((tech) => (
-                <span
-                  key={tech}
-                  className="rounded border border-blue-200 bg-blue-50 px-2 py-1 text-sm font-bold text-blue-900"
-                >
-                  {tech}
-                </span>
-              ))}
-            </div>
+          <aside className="mc-panel h-fit p-5 lg:sticky lg:top-24">
+            <h2 className="text-xl font-black text-[#0B1220]">Stack</h2>
+            <StackChips items={caseStudy.stack} className="mt-4" />
 
-            <h2 className="mt-6 text-xl font-bold text-gray-900">Related links</h2>
-            <div className="mt-3 grid gap-2">
+            <h2 className="mt-7 text-xl font-black text-[#0B1220]">Related links</h2>
+            <div className="mt-4 grid gap-2">
               {caseStudy.links.map((link) =>
                 link.to ? (
                   <Link
@@ -155,7 +174,7 @@ function CaseStudy() {
                         link_type: "internal",
                       })
                     }
-                    className="inline-flex items-center rounded bg-blue-700 px-3 py-2 text-sm font-bold text-white transition-colors hover:bg-blue-800 focus:outline-none focus:ring-2 focus:ring-blue-900 focus:ring-offset-2"
+                    className="mc-button-light"
                   >
                     {link.label}
                     <FaArrowRight className="ml-2" aria-hidden="true" />
@@ -175,7 +194,7 @@ function CaseStudy() {
                         link_type: "external",
                       })
                     }
-                    className="inline-flex items-center rounded bg-slate-800 px-3 py-2 text-sm font-bold text-white transition-colors hover:bg-slate-900 focus:outline-none focus:ring-2 focus:ring-slate-900 focus:ring-offset-2"
+                    className="inline-flex items-center justify-center rounded-md border border-[#F96302]/35 bg-[#F96302]/10 px-4 py-2 text-sm font-black text-[#b94600] transition hover:bg-[#F96302]/15 focus:outline-none focus:ring-2 focus:ring-[#F96302] focus:ring-offset-2"
                   >
                     {link.label}
                     <FaExternalLinkAlt className="ml-2" aria-hidden="true" />
@@ -185,9 +204,9 @@ function CaseStudy() {
             </div>
           </aside>
         </div>
-      </article>
-    </main>
-  )
+      </PageContainer>
+    </PageShell>
+  );
 }
 
-export default CaseStudy
+export default CaseStudy;

--- a/main/src/pages/Contact.jsx
+++ b/main/src/pages/Contact.jsx
@@ -1,25 +1,43 @@
-import React from 'react'
-import ContactForm from '../components/ContactForm'
-import SocialLinks from '../components/SocialLinks'
-import { contact } from '../data/profile'
+import React from "react";
+import ContactForm from "../components/ContactForm";
+import {
+  PageContainer,
+  PageShell,
+  SectionHeader,
+  StatusBadge,
+} from "../components/MissionControl.jsx";
+import SocialLinks from "../components/SocialLinks";
+import { contact } from "../data/profile";
 
 function Contact() {
-    return (
-        <div className="bg-[#02A8DA] bg-opacity-40 min-h-screen">
-          <div className='flex flex-col items-center p-4 font-cambria'>
-              <h1 className="mb-4 text-center text-3xl font-bold text-gray-800">
-                  {contact.heading}
-              </h1>
-              <p className="text-lg text-gray-800 mb-4 max-w-2xl text-center">
-                  {contact.intro}
-              </p>
-              <div className="w-full flex justify-center">
-                  <ContactForm />
-              </div>
-              <p className='text-lg font-bold leading-relaxed text-gray-700 mb-4 -mt-4'>Alternatively, connect with me here</p>
-              <SocialLinks placement="contact" />
-          </div>
-        </div>
-    )
+  return (
+    <PageShell className="mc-dark-field text-white">
+      <PageContainer className="max-w-5xl">
+        <SectionHeader
+          eyebrow="Contact intake"
+          title={contact.heading}
+          description={contact.intro}
+          align="center"
+          tone="dark"
+        />
+
+        <section className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_18rem]">
+          <ContactForm />
+
+          <aside className="h-fit rounded-lg border border-white/10 bg-white/[0.08] p-5">
+            <StatusBadge tone="green">Open channel</StatusBadge>
+            <h2 className="mt-4 text-xl font-black text-white">
+              Alternative routes
+            </h2>
+            <p className="mt-3 text-sm leading-relaxed text-slate-300">
+              LinkedIn, GitHub, and email stay available for quick professional conversations.
+            </p>
+            <SocialLinks placement="contact" className="mt-5 grid gap-2" />
+          </aside>
+        </section>
+      </PageContainer>
+    </PageShell>
+  );
 }
-export default Contact
+
+export default Contact;

--- a/main/src/pages/Contact.jsx
+++ b/main/src/pages/Contact.jsx
@@ -32,7 +32,7 @@ function Contact() {
             <p className="mt-3 text-sm leading-relaxed text-slate-300">
               LinkedIn, GitHub, and email stay available for quick professional conversations.
             </p>
-            <SocialLinks placement="contact" className="mt-5 grid gap-2" />
+            <SocialLinks placement="contact" surface="dark" className="mt-5 grid gap-2" />
           </aside>
         </section>
       </PageContainer>

--- a/main/src/pages/Experience.jsx
+++ b/main/src/pages/Experience.jsx
@@ -1,7 +1,13 @@
 import React from "react";
-import ExperienceCard from "../components/ExperienceCard";
-import OwnershipCard from "../components/OwnershipCard";
 import { HiCog, HiLockClosed, HiServer, HiShieldCheck } from "react-icons/hi";
+import ExperienceCard from "../components/ExperienceCard";
+import {
+  ImpactBand,
+  PageContainer,
+  PageShell,
+  PresentationPanel,
+  SectionHeader,
+} from "../components/MissionControl.jsx";
 import {
   experiencePage,
   extracurricularExperiences,
@@ -16,81 +22,159 @@ const ownershipIconById = {
   cog: HiCog,
 };
 
-const ExperienceGrid = ({ experiences, isExtracurricular, centerIndex }) => {
-  return (
-    <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-      {experiences.map((exp, index) => (
-        <div
-          key={exp.id}
-          className={`w-full ${
-            index === centerIndex ? "md:col-span-2 flex justify-center" : ""
-          }`}
-        >
-          <div
-            className={`w-full ${
-              index === centerIndex ? "md:w-3/4 lg:w-1/2" : ""
-            }`}
-          >
-            <ExperienceCard {...exp} isExtracurricular={isExtracurricular} />
-          </div>
-        </div>
-      ))}
-    </div>
-  );
+const impactMetrics = [
+  {
+    value: "60+",
+    label: "shared-service repositories",
+    detail: "Production ownership across platform services.",
+  },
+  {
+    value: "89%",
+    label: "fewer production errors",
+    detail: "Measured after HPA validation.",
+    tone: "orange",
+  },
+  {
+    value: "8",
+    label: "legacy repos recovered",
+    detail: "Deployment workflows rebuilt for credential rotation.",
+  },
+  {
+    value: "500+",
+    label: "stores supported",
+    detail: "Transaction-critical issue resolution and support.",
+  },
+];
+
+const timelineRankById = {
+  "fintech-gt-frontend-engineer": 0,
+  "home-depot-intern-2024": 1,
+  "cdc-project-manager-full-stack-developer": 2,
+  "home-depot-intern-2023": 3,
+  "gt-undergraduate-teaching-assistant": 4,
+  "landis-gyr-firmware-intern": 5,
 };
 
-function Experience() {
+function TimelineEntry({ experience }) {
   return (
-    <div className="bg-blue-300 min-h-screen py-4 font-cambria">
-      <div className="max-w-6xl mx-auto px-4 space-y-10">
-        <section>
-          <h1 className="text-3xl text-center font-bold mb-6">
-            {experiencePage.workHeading}
-          </h1>
+    <article className="relative border-l border-slate-300 pb-8 pl-6 last:pb-0">
+      <span className="absolute -left-2 top-1 h-4 w-4 rounded-full border-2 border-[#F4F1EA] bg-[#2563EB]" />
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h3 className="text-xl font-black text-[#0B1220]">{experience.title}</h3>
+          <p className="mt-1 font-bold text-slate-700">{experience.company}</p>
+        </div>
+        <div className="text-sm font-bold text-slate-500 sm:text-right">
+          <p>{experience.date}</p>
+          <p>{experience.location}</p>
+        </div>
+      </div>
+      <ul className="mt-4 space-y-2">
+        {experience.bullets.slice(0, 3).map((bullet) => (
+          <li key={bullet} className="text-sm leading-relaxed text-slate-600">
+            {bullet}
+          </li>
+        ))}
+      </ul>
+    </article>
+  );
+}
 
-          <ExperienceGrid
-            experiences={workExperiences}
-            isExtracurricular={false}
-          />
-        </section>
+function Experience() {
+  const [currentRole, ...earlierWork] = workExperiences;
+  const timelineExperiences = [...earlierWork, ...extracurricularExperiences].sort(
+    (a, b) => (timelineRankById[a.id] ?? 99) - (timelineRankById[b.id] ?? 99)
+  );
 
-        <section>
-          <h2 className="text-3xl text-center font-bold mb-2">
-            {experiencePage.ownershipHeading}
-          </h2>
-          <p className="text-center text-gray-600 text-sm mb-8">
-            {experiencePage.ownershipEyebrow}
-          </p>
+  return (
+    <PageShell>
+      <PageContainer className="space-y-12">
+        <SectionHeader
+          eyebrow="Career story"
+          title={experiencePage.workHeading}
+          description="Production ownership across more than 60 shared-service repositories, with reliability, deployment automation, observability, and incident response work tied to measurable outcomes."
+        />
 
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
-            {ownershipAreas.map((area) => {
-              const Icon = ownershipIconById[area.icon];
-              return (
-                <OwnershipCard
-                  key={area.id}
-                  icon={<Icon className="text-blue-600" />}
-                  title={area.title}
-                  summary={area.summary}
-                  details={area.details}
-                />
-              );
-            })}
+        <ImpactBand items={impactMetrics} />
+
+        {currentRole ? (
+          <PresentationPanel
+            aria-labelledby="current-role-heading"
+            className="p-5 text-white sm:p-7"
+          >
+            <div className="relative z-10 grid gap-8 lg:grid-cols-[minmax(0,0.98fr)_minmax(24rem,1.02fr)] lg:items-stretch">
+              <div>
+                <p className="text-xs font-black uppercase tracking-[0.18em] text-[#FFB077]">
+                  {experiencePage.ownershipEyebrow}
+                </p>
+                <h2
+                  id="current-role-heading"
+                  className="mt-5 text-4xl font-black leading-tight sm:text-5xl"
+                >
+                  Platform ownership as a connected production system.
+                </h2>
+                <p className="mt-5 text-lg leading-relaxed text-slate-300">
+                  The role spans release safety, shared infrastructure, incident
+                  response, and production recovery for transaction-critical systems.
+                </p>
+
+                <div className="mt-8 grid gap-4">
+                  {ownershipAreas.map((area, index) => {
+                    const Icon = ownershipIconById[area.icon];
+                    return (
+                      <article
+                        key={area.id}
+                        className="relative border-l-2 border-white/15 pl-5"
+                      >
+                        <span
+                          className={`absolute -left-[9px] top-0 flex h-4 w-4 items-center justify-center rounded-full ${
+                            index === 1 ? "bg-[#F96302]" : "bg-[#2563EB]"
+                          }`}
+                        />
+                        <div className="flex items-start gap-3">
+                          <span className="mt-1 text-[#F96302]">
+                            <Icon className="h-5 w-5" aria-hidden="true" />
+                          </span>
+                          <div>
+                            <h3 className="text-lg font-black">{area.title}</h3>
+                            <p className="mt-2 text-sm leading-relaxed text-slate-300">
+                              {area.summary}
+                            </p>
+                          </div>
+                        </div>
+                      </article>
+                    );
+                  })}
+                </div>
+              </div>
+
+              <ExperienceCard {...currentRole} featured />
+            </div>
+          </PresentationPanel>
+        ) : null}
+
+        <section
+          aria-labelledby="earlier-roles-heading"
+          className="grid gap-8 lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]"
+        >
+          <div>
+            <p className="mc-eyebrow">Earlier roles</p>
+            <h2
+              id="earlier-roles-heading"
+              className="text-3xl font-black text-[#0B1220]"
+            >
+              Foundation work, internships, and technical leadership.
+            </h2>
+          </div>
+
+          <div className="mc-panel p-5">
+            {timelineExperiences.map((experience) => (
+              <TimelineEntry key={experience.id} experience={experience} />
+            ))}
           </div>
         </section>
-
-        <section>
-          <h2 className="text-3xl text-center font-bold mb-8">
-            {experiencePage.extracurricularHeading}
-          </h2>
-
-          <ExperienceGrid
-            experiences={extracurricularExperiences}
-            isExtracurricular={true}
-            centerIndex={experiencePage.centeredExtracurricularIndex}
-          />
-        </section>
-      </div>
-    </div>
+      </PageContainer>
+    </PageShell>
   );
 }
 

--- a/main/src/pages/Home.jsx
+++ b/main/src/pages/Home.jsx
@@ -1,101 +1,326 @@
-import React, { useLayoutEffect, useRef, useState } from "react";
-import { FaDownload } from "react-icons/fa";
+import React from "react";
+import { Link } from "react-router-dom";
+import {
+  FaArrowRight,
+  FaChartLine,
+  FaCogs,
+  FaDownload,
+  FaMapMarkerAlt,
+  FaNetworkWired,
+  FaRegClock,
+  FaServer,
+} from "react-icons/fa";
 import DeployDates from "../components/DeployDates";
+import {
+  ImpactBand,
+  PageContainer,
+  PageShell,
+  PresentationPanel,
+  SignalCard,
+  StackChips,
+  StatusBadge,
+  SystemDiagram,
+} from "../components/MissionControl.jsx";
 import SocialLinks from "../components/SocialLinks";
 import { deployInfo, profile, resume } from "../data/profile";
 import { trackEvent } from "../utils/analytics";
 
+const impactMetrics = [
+  {
+    value: "34.8M",
+    label: "weekly requests",
+    detail: "Validated autoscaling under production load.",
+  },
+  {
+    value: "89%",
+    label: "fewer errors",
+    detail: "Measured after HPA rollout on a core service.",
+    tone: "orange",
+  },
+  {
+    value: "60+",
+    label: "repositories supported",
+    detail: "Shared-service ownership across platform work.",
+  },
+  {
+    value: "5000+",
+    label: "hours saved annually",
+    detail: "Manual reconciliation converted into workflows.",
+  },
+];
+
+const focusAreas = [
+  "Kubernetes autoscaling",
+  "CI/CD recovery",
+  "Observability",
+  "Incident response",
+  "Deployment automation",
+  "High-throughput systems",
+];
+
+const heroSignals = [
+  {
+    label: "Problem",
+    title: "Production systems cannot depend on guesswork.",
+    detail: "Traffic, releases, incidents, and legacy paths need evidence-rich ownership.",
+  },
+  {
+    label: "Approach",
+    title: "Trace the system before changing it.",
+    detail: "I pair deployment work with observability, validation, and rollback-aware thinking.",
+  },
+  {
+    label: "Outcome",
+    title: "Make reliability legible to technical and hiring audiences.",
+    detail: "The portfolio surfaces impact first, then keeps the engineering trail inspectable.",
+  },
+];
+
+const autoscalingNodes = [
+  {
+    label: "Traffic baseline",
+    detail: "24.9M req/wk",
+    tone: "blue",
+    icon: FaNetworkWired,
+  },
+  {
+    label: "HPA policy",
+    detail: "50-100 pods",
+    tone: "orange",
+    icon: FaServer,
+  },
+  {
+    label: "Grafana",
+    detail: "Latency + errors",
+    tone: "green",
+    icon: FaRegClock,
+  },
+  {
+    label: "Throughput",
+    detail: "34.8M req/wk",
+    tone: "blue",
+    icon: FaChartLine,
+  },
+  {
+    label: "CPU pressure",
+    detail: "26% lower",
+    tone: "purple",
+    icon: FaCogs,
+  },
+  {
+    label: "Recovery",
+    detail: "89% fewer errors",
+    tone: "orange",
+    icon: FaArrowRight,
+  },
+];
+
+const routeCards = [
+  {
+    label: "Case Studies",
+    to: "/case-studies",
+    title: "Production outcomes",
+    detail: "Reliability, deployment recovery, and data systems with measurable results.",
+  },
+  {
+    label: "Experience",
+    to: "/experience",
+    title: "Career story",
+    detail: "Platform ownership, release governance, infrastructure auth, and recovery work.",
+  },
+  {
+    label: "Projects",
+    to: "/projects",
+    title: "Build portfolio",
+    detail: "Full-stack and mobile projects shaped around practical workflows.",
+  },
+];
+
 function Home() {
-  const introRef = useRef(null);
-  const [introHeight, setIntroHeight] = useState(null);
-
-  useLayoutEffect(() => {
-    const intro = introRef.current;
-    if (!intro) return undefined;
-
-    const updateIntroHeight = () => {
-      setIntroHeight(Math.ceil(intro.getBoundingClientRect().height));
-    };
-
-    updateIntroHeight();
-
-    if (typeof ResizeObserver === "undefined") {
-      window.addEventListener("resize", updateIntroHeight);
-      return () => window.removeEventListener("resize", updateIntroHeight);
-    }
-
-    const resizeObserver = new ResizeObserver(updateIntroHeight);
-    resizeObserver.observe(intro);
-
-    return () => resizeObserver.disconnect();
-  }, []);
-
   return (
-    <div className="min-h-screen flex flex-col font-cambria">
-      <nav className="bg-blue-100 p-4">
-        <div className="flex flex-col sm:flex-row justify-between items-center">
-          <div className="flex items-center mb-4 sm:mb-0">
-            <img
-              src={profile.educationLogo}
-              alt="Georgia Tech Logo"
-              className="h-16 w-auto"
-            />
-          </div>
-          <div className="flex-grow text-center mb-4 sm:mb-0">
-            <h1 className="text-3xl font-bold text-gray-700">{profile.name}</h1>
-            <p className="text-xl text-gray-700">
-              {profile.tagline}
+    <PageShell>
+      <section className="mc-dark-field px-3 py-4 text-white sm:px-5 sm:py-7">
+        <PageContainer className="max-w-7xl py-0 sm:py-0">
+          <PresentationPanel className="p-5 sm:p-8 lg:p-10">
+            <div className="relative z-10 grid min-h-[calc(100dvh-8rem)] gap-10 lg:grid-cols-[minmax(0,1.05fr)_minmax(20rem,0.95fr)] lg:items-center">
+              <div className="mc-rise">
+                <p className="text-xs font-black uppercase tracking-[0.18em] text-[#FFB077]">
+                  Platform & Reliability Engineering
+                </p>
+                <div className="mc-line-reveal mt-4 h-px w-40 bg-[#F96302]" aria-hidden="true" />
+
+                <h1 className="mt-8 max-w-4xl text-5xl font-black leading-none sm:text-7xl">
+                  {profile.name}
+                </h1>
+                <p className="mt-5 max-w-3xl text-2xl font-black leading-tight text-white sm:text-3xl">
+                  I build production systems that stay reliable under pressure.
+                </p>
+                <p className="mt-5 max-w-2xl text-base leading-relaxed text-slate-300 sm:text-lg">
+                  Software engineer focused on Kubernetes, deployment automation,
+                  observability, and high-throughput backend systems.
+                </p>
+
+                <div className="mt-8 flex flex-wrap gap-3">
+                  <a
+                    href={resume.pdf}
+                    download
+                    onClick={() =>
+                      trackEvent("resume_download", {
+                        placement: "home_header",
+                      })
+                    }
+                    className="mc-button-primary"
+                  >
+                    <FaDownload className="mr-2" aria-hidden="true" />
+                    Download Resume
+                  </a>
+                  <Link to="/contact" className="mc-button-secondary">
+                    Contact
+                    <FaArrowRight className="ml-2" aria-hidden="true" />
+                  </Link>
+                </div>
+
+                <StackChips items={focusAreas} className="mt-8" />
+              </div>
+
+              <aside className="relative mx-auto w-full max-w-md lg:mr-0">
+                <div className="absolute -right-3 -top-3 h-28 w-28 border-r-4 border-t-4 border-[#B3A369]" aria-hidden="true" />
+                <div className="absolute -bottom-3 -left-3 h-28 w-28 border-b-4 border-l-4 border-[#F96302]" aria-hidden="true" />
+
+                <div className="relative overflow-hidden rounded-3xl border border-white/15 bg-white/5 p-2 shadow-[0_26px_80px_rgba(0,0,0,0.36)]">
+                  <img
+                    src={profile.profilePicture}
+                    alt={profile.name}
+                    className="h-[30rem] w-full rounded-2xl object-cover object-center"
+                  />
+                </div>
+
+                <div className="absolute left-4 top-4 rounded-2xl border border-white/15 bg-[#0B1220]/90 px-4 py-3 text-sm shadow-[0_18px_40px_rgba(0,0,0,0.28)] backdrop-blur">
+                  <p className="font-black">Software Engineer</p>
+                  <p className="mt-1 flex items-center gap-2 text-slate-300">
+                    <FaMapMarkerAlt className="h-3 w-3 text-[#F96302]" aria-hidden="true" />
+                    Atlanta, GA
+                  </p>
+                </div>
+
+                <div className="absolute -right-1 bottom-24 rounded-2xl border border-white/15 bg-white px-4 py-3 text-[#0B1220] shadow-[0_18px_50px_rgba(0,0,0,0.24)]">
+                  <p className="text-3xl font-black">34.8M</p>
+                  <p className="text-xs font-black uppercase text-slate-600">weekly requests</p>
+                </div>
+
+                <div className="absolute -left-1 bottom-8 rounded-2xl border border-white/15 bg-[#0B1220] px-4 py-3 text-white shadow-[0_18px_50px_rgba(0,0,0,0.24)]">
+                  <p className="text-3xl font-black text-[#F96302]">500+</p>
+                  <p className="text-xs font-black uppercase text-slate-300">stores supported</p>
+                </div>
+              </aside>
+            </div>
+
+            <div className="relative z-10 mt-8 grid gap-4 lg:grid-cols-3">
+              {heroSignals.map((signal) => (
+                <SignalCard key={signal.label} {...signal} />
+              ))}
+            </div>
+          </PresentationPanel>
+        </PageContainer>
+      </section>
+
+      <section className="bg-[#F4F1EA]">
+        <PageContainer className="space-y-8">
+          <ImpactBand items={impactMetrics} />
+
+          <div className="grid gap-6 lg:grid-cols-[0.85fr_1.15fr] lg:items-center">
+            <div>
+              <p className="mc-eyebrow">Engineering signal</p>
+              <h2 className="text-4xl font-black leading-tight text-[#0B1220]">
+                Reliable systems first. Technical depth immediately after the scan.
+              </h2>
+            </div>
+            <p className="text-lg leading-relaxed text-slate-600">
+              {profile.intro}
             </p>
           </div>
-          <div className="mb-4 sm:mb-0">
-            <a
-              href={resume.pdf}
-              download
-              onClick={() =>
-                trackEvent("resume_download", {
-                  placement: "home_header",
-                })
-              }
-              className="bg-blue-500 text-white px-4 py-2 rounded hover:bg-green-600 transition-colors inline-flex items-center"
-            >
-              <FaDownload className="mr-2" />
-              Download Resume
-            </a>
+        </PageContainer>
+      </section>
+
+      <section className="mc-blue-section text-white">
+        <PageContainer className="grid gap-8 lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)] lg:items-center">
+          <div>
+            <StatusBadge tone="orange">Featured case study</StatusBadge>
+            <h2 className="mt-5 text-4xl font-black leading-tight sm:text-5xl">
+              Kubernetes autoscaling for transaction-critical services.
+            </h2>
+            <p className="mt-5 text-lg leading-relaxed text-[#DCE8FF]">
+              A core service moved from fixed static capacity to validated dynamic
+              scaling, improving latency, errors, throughput, and CPU efficiency
+              under production traffic.
+            </p>
+            <Link to="/case-studies/kubernetes-autoscaling" className="mc-button-primary mt-7">
+              Read the case study
+              <FaArrowRight className="ml-2" aria-hidden="true" />
+            </Link>
           </div>
-        </div>
-      </nav>
 
-      <main className="flex-grow bg-blue-100">
-        <div className="container mx-auto px-4">
-          <section className="py-12">
-            <div className="flex flex-col md:flex-row justify-center items-start gap-8 max-w-4xl mx-auto">
-              <div className="w-full md:w-1/2 flex-grow">
-                <p ref={introRef} className="text-lg leading-relaxed text-gray-700">
-                  {profile.intro}
-                </p>
-              </div>
+          <div className="rounded-[1.75rem] border border-white/10 bg-white/[0.075] p-4 shadow-[0_24px_70px_rgba(0,0,0,0.22)] sm:p-5">
+            <SystemDiagram
+              centerLabel="Autoscaling rollout"
+              centerDetail="Production reliability"
+              nodes={autoscalingNodes}
+              caption="The rollout connected traffic baselines, Kubernetes scaling behavior, and observability signals before declaring the outcome."
+            />
+            <ImpactBand
+              surface="dark"
+              className="mc-impact-band-compact mt-5 lg:grid-cols-4"
+              items={[
+                { value: "40%", label: "lower latency" },
+                { value: "89%", label: "fewer errors", tone: "orange" },
+                { value: "26%", label: "lower CPU" },
+                { value: "50-100", label: "dynamic pods" },
+              ]}
+            />
+          </div>
+        </PageContainer>
+      </section>
 
-              <div className="w-full md:w-1/2 flex justify-center items-start -mt-2">
-                <img
-                  src={profile.profilePicture}
-                  alt={profile.name}
-                  className="w-auto max-w-full object-cover rounded-lg shadow-lg"
-                  style={introHeight ? { height: `${introHeight}px` } : undefined}
-                />
-              </div>
-            </div>
+      <section className="bg-[#E8EDF2]">
+        <PageContainer className="space-y-8">
+          <div>
+            <p className="mc-eyebrow">Explore</p>
+            <h2 className="max-w-3xl text-4xl font-black leading-tight text-[#0B1220]">
+              Inspect the portfolio through outcomes, ownership, or builds.
+            </h2>
+          </div>
 
-            <div className="flex flex-col items-center mt-4">
-              <p className="text-lg font-bold leading-relaxed text-gray-700 mb-2">
-                Connect with me
-              </p>
-              <SocialLinks placement="home" />
-            </div>
-            <DeployDates first={deployInfo.firstPublishedAt} />
-          </section>
-        </div>
-      </main>
-    </div>
+          <div className="grid gap-4 lg:grid-cols-3" aria-label="Portfolio routes">
+            {routeCards.map((card) => (
+              <Link
+                key={card.to}
+                to={card.to}
+                className="mc-panel group block p-5 transition hover:-translate-y-1 hover:border-[#2563EB]/40 focus:outline-none focus:ring-2 focus:ring-[#2563EB] focus:ring-offset-2 motion-reduce:hover:translate-y-0"
+              >
+                <p className="text-xs font-black uppercase text-[#2563EB]">{card.label}</p>
+                <h3 className="mt-3 text-2xl font-black text-[#0B1220]">{card.title}</h3>
+                <p className="mt-3 text-sm leading-relaxed text-slate-600">{card.detail}</p>
+                <span className="mt-5 inline-flex items-center text-sm font-black text-[#0B1220]">
+                  Open
+                  <FaArrowRight
+                    className="ml-2 text-[#F96302] transition group-hover:translate-x-1 motion-reduce:group-hover:translate-x-0"
+                    aria-hidden="true"
+                  />
+                </span>
+              </Link>
+            ))}
+          </div>
+
+          <div className="mc-panel p-5">
+            <p className="text-sm font-black uppercase text-slate-500">Connect</p>
+            <SocialLinks placement="home" className="mt-4 flex flex-wrap gap-2" />
+          </div>
+
+          <DeployDates first={deployInfo.firstPublishedAt} />
+        </PageContainer>
+      </section>
+    </PageShell>
   );
 }
+
 export default Home;

--- a/main/src/pages/Home.jsx
+++ b/main/src/pages/Home.jsx
@@ -16,7 +16,6 @@ import {
   PageContainer,
   PageShell,
   PresentationPanel,
-  SignalCard,
   StackChips,
   StatusBadge,
   SystemDiagram,
@@ -27,8 +26,8 @@ import { trackEvent } from "../utils/analytics";
 
 const impactMetrics = [
   {
-    value: "34.8M",
-    label: "weekly requests",
+    value: "40%",
+    label: "lower latency",
     detail: "Validated autoscaling under production load.",
   },
   {
@@ -58,23 +57,7 @@ const focusAreas = [
   "High-throughput systems",
 ];
 
-const heroSignals = [
-  {
-    label: "Problem",
-    title: "Production systems cannot depend on guesswork.",
-    detail: "Traffic, releases, incidents, and legacy paths need evidence-rich ownership.",
-  },
-  {
-    label: "Approach",
-    title: "Trace the system before changing it.",
-    detail: "I pair deployment work with observability, validation, and rollback-aware thinking.",
-  },
-  {
-    label: "Outcome",
-    title: "Make reliability legible to technical and hiring audiences.",
-    detail: "The portfolio surfaces impact first, then keeps the engineering trail inspectable.",
-  },
-];
+
 
 const autoscalingNodes = [
   {
@@ -159,6 +142,10 @@ function Home() {
                   Software engineer focused on Kubernetes, deployment automation,
                   observability, and high-throughput backend systems.
                 </p>
+                <p className="mt-4 flex items-center gap-2 text-sm text-slate-400">
+                  <FaMapMarkerAlt className="h-3 w-3 text-[#F96302]" aria-hidden="true" />
+                  Atlanta, GA
+                </p>
 
                 <div className="mt-8 flex flex-wrap gap-3">
                   <a
@@ -195,31 +182,11 @@ function Home() {
                   />
                 </div>
 
-                <div className="absolute left-4 top-4 rounded-2xl border border-white/15 bg-[#0B1220]/90 px-4 py-3 text-sm shadow-[0_18px_40px_rgba(0,0,0,0.28)] backdrop-blur">
-                  <p className="font-black">Software Engineer</p>
-                  <p className="mt-1 flex items-center gap-2 text-slate-300">
-                    <FaMapMarkerAlt className="h-3 w-3 text-[#F96302]" aria-hidden="true" />
-                    Atlanta, GA
-                  </p>
-                </div>
 
-                <div className="absolute -right-1 bottom-24 rounded-2xl border border-white/15 bg-white px-4 py-3 text-[#0B1220] shadow-[0_18px_50px_rgba(0,0,0,0.24)]">
-                  <p className="text-3xl font-black">34.8M</p>
-                  <p className="text-xs font-black uppercase text-slate-600">weekly requests</p>
-                </div>
-
-                <div className="absolute -left-1 bottom-8 rounded-2xl border border-white/15 bg-[#0B1220] px-4 py-3 text-white shadow-[0_18px_50px_rgba(0,0,0,0.24)]">
-                  <p className="text-3xl font-black text-[#F96302]">500+</p>
-                  <p className="text-xs font-black uppercase text-slate-300">stores supported</p>
-                </div>
               </aside>
             </div>
 
-            <div className="relative z-10 mt-8 grid gap-4 lg:grid-cols-3">
-              {heroSignals.map((signal) => (
-                <SignalCard key={signal.label} {...signal} />
-              ))}
-            </div>
+
           </PresentationPanel>
         </PageContainer>
       </section>

--- a/main/src/pages/NotFound.jsx
+++ b/main/src/pages/NotFound.jsx
@@ -1,28 +1,24 @@
-import React from "react"
-import { Link } from "react-router-dom"
+import React from "react";
+import { Link } from "react-router-dom";
+import { PageContainer, PageShell, StatusBadge } from "../components/MissionControl.jsx";
 
 function NotFound() {
   return (
-    <main className="min-h-screen bg-blue-100 px-4 py-16 font-cambria">
-      <section className="mx-auto flex max-w-2xl flex-col items-center text-center">
-        <p className="mb-3 text-sm font-bold uppercase tracking-wide text-blue-700">
-          404
-        </p>
-        <h1 className="mb-4 text-4xl font-bold text-gray-800">
-          Page not found
-        </h1>
-        <p className="mb-6 text-lg leading-relaxed text-gray-700">
-          That page does not exist, but the portfolio is still right here.
-        </p>
-        <Link
-          to="/"
-          className="rounded bg-blue-600 px-4 py-2 font-bold text-white transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2"
-        >
-          Go home
-        </Link>
-      </section>
-    </main>
-  )
+    <PageShell>
+      <PageContainer className="flex min-h-[60dvh] items-center justify-center">
+        <section className="mc-panel max-w-2xl p-8 text-center">
+          <StatusBadge tone="orange">404</StatusBadge>
+          <h1 className="mt-5 text-4xl font-black text-[#0B1220]">Page not found</h1>
+          <p className="mt-4 text-lg leading-relaxed text-slate-600">
+            That route is outside the portfolio map, but the main site is ready.
+          </p>
+          <Link to="/" className="mc-button-light mt-6">
+            Go home
+          </Link>
+        </section>
+      </PageContainer>
+    </PageShell>
+  );
 }
 
-export default NotFound
+export default NotFound;

--- a/main/src/pages/Projects.jsx
+++ b/main/src/pages/Projects.jsx
@@ -1,62 +1,163 @@
 import React from "react";
-import { FaCodeBranch, FaDatabase, FaMobileAlt } from "react-icons/fa";
+import { FaCodeBranch, FaDatabase, FaMobileAlt, FaUsers } from "react-icons/fa";
+import {
+  ImpactBand,
+  PageContainer,
+  PageShell,
+  PresentationPanel,
+  SectionHeader,
+  StackChips,
+  StatusBadge,
+  SystemDiagram,
+} from "../components/MissionControl.jsx";
 import ProjectCard from "../components/ProjectCard";
 import { projectStats, projects, projectsPage } from "../data/projects";
 
-const statIconById = {
-  branch: FaCodeBranch,
-  database: FaDatabase,
-  mobile: FaMobileAlt,
+const statDetailById = {
+  repos: "Public repositories with visible implementation work.",
+  "data-apps": "Data-heavy tools for reconciliation and workflow support.",
+  mobile: "Android experiences built around practical user flows.",
 };
 
-function Projects() {
-  return (
-    <div className="bg-blue-300 min-h-screen">
-      <div className="container mx-auto px-4 py-8 font-cambria">
-        <header className="mx-auto mb-10 max-w-6xl">
-          <div className="grid gap-5 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
-            <div className="relative pl-5">
-              <span className="absolute left-0 top-1 h-[calc(100%-0.5rem)] w-1 rounded bg-blue-800" />
-              <h1 className="max-w-3xl text-4xl font-bold leading-tight text-gray-900 sm:text-5xl">
-                {projectsPage.title}
-              </h1>
-              <p className="mt-4 max-w-2xl text-lg leading-relaxed text-gray-700">
-                {projectsPage.description}
-              </p>
-            </div>
+const projectFlowNodes = [
+  {
+    label: "State datasets",
+    detail: "50 departments",
+    tone: "blue",
+    icon: FaDatabase,
+  },
+  {
+    label: "Python compare",
+    detail: "Discrepancy checks",
+    tone: "orange",
+    icon: FaCodeBranch,
+  },
+  {
+    label: "FastAPI stats",
+    detail: "Reviewable metrics",
+    tone: "green",
+    icon: FaDatabase,
+  },
+  {
+    label: "React review",
+    detail: "Filtering UI",
+    tone: "blue",
+    icon: FaMobileAlt,
+  },
+  {
+    label: "Stakeholders",
+    detail: "25+ reviewers",
+    tone: "purple",
+    icon: FaUsers,
+  },
+  {
+    label: "Saved time",
+    detail: "5000+ hours",
+    tone: "orange",
+    icon: FaCodeBranch,
+  },
+];
 
-            <div className="grid grid-cols-3 gap-3 text-center text-gray-800 md:min-w-[18rem]">
-              {projectStats.map((stat) => {
-                const Icon = statIconById[stat.icon];
-                return (
-                  <div key={stat.id} className="px-2">
-                    <Icon className="mx-auto mb-2 text-blue-800" />
-                    <p className="text-2xl font-bold">{stat.value}</p>
-                    <p className="text-xs font-bold uppercase tracking-wide text-gray-600">
-                      {stat.label}
+function Projects() {
+  const featuredProject = projects.find(
+    (project) => project.id === "cdc-data-reconciliation"
+  );
+  const supportingProjects = projects.filter(
+    (project) => project.id !== "cdc-data-reconciliation"
+  );
+
+  return (
+    <PageShell>
+      <PageContainer className="space-y-10">
+        <SectionHeader
+          eyebrow="Project portfolio"
+          title={projectsPage.title}
+          description={projectsPage.description}
+        />
+
+        <ImpactBand
+          items={projectStats.map((stat) => ({
+            value: stat.value,
+            label: stat.label,
+            detail: statDetailById[stat.id],
+            tone: stat.id === "data-apps" ? "orange" : undefined,
+          }))}
+        />
+
+        {featuredProject ? (
+          <PresentationPanel
+            aria-labelledby="featured-project-heading"
+            className="p-5 text-white sm:p-7"
+          >
+            <div className="relative z-10 grid gap-7 lg:grid-cols-[minmax(0,0.92fr)_minmax(21rem,1.08fr)] lg:items-center">
+              <div>
+                <StatusBadge tone="orange">Featured project</StatusBadge>
+                <h2
+                  id="featured-project-heading"
+                  className="mt-5 text-4xl font-black leading-tight sm:text-5xl"
+                >
+                  Featured public-health reconciliation system
+                </h2>
+                <p className="mt-4 text-lg leading-relaxed text-slate-300">
+                  Led a six-person team while contributing full-stack work on a
+                  public health reconciliation platform that saved 5000+ hours
+                  of manual review annually.
+                </p>
+
+                <div className="mt-6 grid gap-3 sm:grid-cols-2">
+                  <div className="border-l-4 border-[#F96302] pl-4">
+                    <p className="text-3xl font-black">5000+</p>
+                    <p className="text-sm font-black uppercase text-slate-300">
+                      annual hours saved
                     </p>
                   </div>
-                );
-              })}
-            </div>
-          </div>
-        </header>
+                  <div className="border-l-4 border-[#2563EB] pl-4">
+                    <p className="text-3xl font-black">6</p>
+                    <p className="text-sm font-black uppercase text-slate-300">
+                      team members led
+                    </p>
+                  </div>
+                </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-          {projects.map((project) => (
-            <ProjectCard
-              key={project.id}
-              id={project.id}
-              title={project.title}
-              techStack={project.techStack}
-              bullets={project.bullets}
-              github={project.github}
-              logo={project.logo}
-            />
-          ))}
-        </div>
-      </div>
-    </div>
+                <SystemDiagram
+                  className="mt-7"
+                  centerLabel="CDC reconciliation"
+                  centerDetail="Data workflow"
+                  nodes={projectFlowNodes}
+                  caption="The project connected public-health datasets, comparison logic, API statistics, and a review interface for faster discrepancy analysis."
+                />
+
+                <StackChips
+                  items={featuredProject.techStack.split(",").map((item) => item.trim())}
+                  className="mt-6"
+                />
+              </div>
+
+              <ProjectCard {...featuredProject} />
+            </div>
+          </PresentationPanel>
+        ) : null}
+
+        <section aria-labelledby="supporting-projects-heading" className="space-y-5">
+          <div>
+            <p className="mc-eyebrow">Supporting builds</p>
+            <h2
+              id="supporting-projects-heading"
+              className="text-3xl font-black text-[#0B1220]"
+            >
+              Mobile and workflow systems
+            </h2>
+          </div>
+
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1.08fr_0.92fr]">
+            {supportingProjects.map((project) => (
+              <ProjectCard key={project.id} {...project} />
+            ))}
+          </div>
+        </section>
+      </PageContainer>
+    </PageShell>
   );
 }
+
 export default Projects;

--- a/main/src/pages/Resume.jsx
+++ b/main/src/pages/Resume.jsx
@@ -1,62 +1,81 @@
-import React from "react"
-import { FaDownload, FaExternalLinkAlt } from "react-icons/fa"
-import { resume } from "../data/profile"
-import { trackEvent } from "../utils/analytics"
+import React from "react";
+import { FaDownload, FaExternalLinkAlt } from "react-icons/fa";
+import {
+  PageContainer,
+  PageShell,
+  SectionHeader,
+  StatusBadge,
+} from "../components/MissionControl.jsx";
+import { resume } from "../data/profile";
+import { trackEvent } from "../utils/analytics";
 
 function Resume() {
   return (
-    <div className="min-h-[calc(100dvh-2.25rem)] bg-[#02A8DA] bg-opacity-25 px-3 py-4 font-cambria sm:p-4">
-      <div className="mx-auto flex w-full max-w-4xl flex-col gap-4">
-        <div className="flex flex-wrap items-center justify-center gap-3">
+    <PageShell>
+      <PageContainer className="max-w-5xl">
+        <SectionHeader
+          eyebrow="Resume artifact"
+          title="Resume"
+          description="A focused snapshot of platform reliability, production ownership, deployment automation, and full-stack project work."
+          align="center"
+        />
+
+        <section className="mc-panel p-4 sm:p-5">
+          <div className="mb-4 flex flex-col gap-3 border-b border-slate-200 pb-4 sm:flex-row sm:items-center sm:justify-between">
+            <StatusBadge tone="green">PDF ready</StatusBadge>
+            <div className="flex flex-wrap justify-center gap-3 sm:justify-end">
+              <a
+                href={resume.pdf}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() =>
+                  trackEvent("resume_open", {
+                    placement: "resume_actions",
+                  })
+                }
+                className="mc-button-light"
+              >
+                <FaExternalLinkAlt className="mr-2" aria-hidden="true" />
+                Open PDF
+              </a>
+              <a
+                href={resume.pdf}
+                download
+                onClick={() =>
+                  trackEvent("resume_download", {
+                    placement: "resume_actions",
+                  })
+                }
+                className="mc-button-primary"
+              >
+                <FaDownload className="mr-2" aria-hidden="true" />
+                Download Resume
+              </a>
+            </div>
+          </div>
+
           <a
             href={resume.pdf}
             target="_blank"
             rel="noopener noreferrer"
+            aria-label="Open Waffy Ahmed resume PDF"
             onClick={() =>
               trackEvent("resume_open", {
-                placement: "resume_actions",
+                placement: "resume_preview",
               })
             }
-            className="inline-flex items-center rounded bg-blue-600 px-4 py-2 font-bold text-white transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-900 focus:ring-offset-2"
+            className="mx-auto block w-full max-w-[900px] rounded-lg border border-slate-200 bg-[#E8EDF2] p-2 shadow-inner transition hover:border-[#2563EB]/50 focus:outline-none focus:ring-2 focus:ring-[#2563EB] focus:ring-offset-2"
           >
-            <FaExternalLinkAlt className="mr-2" aria-hidden="true" />
-            Open PDF
+            <img
+              src={resume.preview}
+              alt="Preview of Waffy Ahmed's resume"
+              className="h-auto w-full rounded-md"
+            />
           </a>
-          <a
-            href={resume.pdf}
-            download
-            onClick={() =>
-              trackEvent("resume_download", {
-                placement: "resume_actions",
-              })
-            }
-            className="inline-flex items-center rounded bg-slate-800 px-4 py-2 font-bold text-white transition-colors hover:bg-slate-900 focus:outline-none focus:ring-2 focus:ring-slate-900 focus:ring-offset-2"
-          >
-            <FaDownload className="mr-2" aria-hidden="true" />
-            Download Resume
-          </a>
-        </div>
-
-        <a
-          href={resume.pdf}
-          target="_blank"
-          rel="noopener noreferrer"
-          aria-label="Open Waffy Ahmed resume PDF"
-          onClick={() =>
-            trackEvent("resume_open", {
-              placement: "resume_preview",
-            })
-          }
-          className="mx-auto block w-full max-w-[900px] rounded border border-blue-200 bg-white p-1.5 shadow-lg transition-shadow hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-blue-900 focus:ring-offset-2 sm:p-2"
-        >
-          <img
-            src={resume.preview}
-            alt="Preview of Waffy Ahmed's resume"
-            className="h-auto w-full rounded-sm"
-          />
-        </a>
-      </div>
-    </div>
-  )
+        </section>
+      </PageContainer>
+    </PageShell>
+  );
 }
-export default Resume
+
+export default Resume;


### PR DESCRIPTION
## Summary
- Redesigns the portfolio into a recruiter-clear Mission Control experience with a graphite/dark presentation shell, light utility panels, status badges, metric bands, system-diagram treatments, orange/cyan/green accents, and reduced-motion-safe interaction polish.
- Rebuilds the homepage around platform reliability positioning, resume/contact CTAs, profile-photo presentation, focus chips, measurable impact metrics, a featured Kubernetes autoscaling case-study path, route cards, social links, and deploy/AI summary utility controls.
- Refreshes Projects, Experience, Case Studies, Resume, Contact, and Not Found around the shared Mission Control component system so the portfolio reads consistently across core routes.
- Improves the Experience page with metric-first impact tiles, a stronger current-role presentation, chronological earlier-role timeline, Home Depot logo treatment, and a more compact featured experience card.
- Restyles project and case-study cards as inspectable system modules with stack chips, source/detail actions, diagrammed workflows, and consistent dark/light panel behavior.
- Converts Contact and Resume into quieter command-center utility views while preserving Formspree fallback/success behavior, social/contact analytics, and resume open/download tracking.
- Adds responsive polish for mobile navigation with a compact horizontal tab strip and active-route visibility, plus dark-surface social link variants for the contact panel.

## Verification
- `npm run lint`
- `npm run test`
- `npm run build`
- Visual inspection of `/experience` and `/contact` at desktop and 390px mobile widths after the final polish pass
- Pre-push hook reran lint, tests, and production build successfully before pushing `dev`

## Notes
- Existing routes, PR branch, resume asset paths, Formspree behavior, and GA4 event semantics are preserved.
- No new frontend dependencies were added.
