### PR TITLE
Add lightweight security automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/main"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:15"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 5
+    versioning-strategy: "increase-if-necessary"
+    groups:
+      runtime-dependencies:
+        dependency-type: "production"
+        patterns:
+          - "*"
+      development-dependencies:
+        dependency-type: "development"
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:45"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 3
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "deps"
+      include: "scope"

--- a/.github/workflows/deployed-security-headers.yml
+++ b/.github/workflows/deployed-security-headers.yml
@@ -1,0 +1,104 @@
+name: Deployed security headers
+
+"on":
+  schedule:
+    - cron: "37 14 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deployed-security-headers
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    name: Verify waffy.dev headers
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check production headers
+        env:
+          SITE_URL: https://waffy.dev/
+        run: |
+          set -euo pipefail
+
+          headers_file="$(mktemp)"
+          status_code="$(curl --silent --show-error --location --head \
+            --retry 3 --retry-delay 5 --connect-timeout 10 --max-time 30 \
+            --dump-header "$headers_file" --output /dev/null \
+            --write-out "%{http_code}" "$SITE_URL")"
+
+          if [ "$status_code" != "200" ]; then
+            echo "Expected HTTP 200 from ${SITE_URL}, got ${status_code}."
+            cat "$headers_file"
+            exit 1
+          fi
+
+          headers="$(tr -d '\r' < "$headers_file")"
+
+          get_header() {
+            local header_name
+            header_name="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+            printf '%s\n' "$headers" | awk -v name="$header_name" '
+              BEGIN { FS = ":" }
+              tolower($1) == name {
+                sub(/^[^:]*:[[:space:]]*/, "", $0)
+                print
+                exit
+              }
+            '
+          }
+
+          require_header_value() {
+            local header_name="$1"
+            local expected_value="$2"
+            local actual_value
+            actual_value="$(get_header "$header_name")"
+
+            if [ "$actual_value" != "$expected_value" ]; then
+              echo "Unexpected ${header_name} header."
+              echo "Expected: ${expected_value}"
+              echo "Actual:   ${actual_value:-<missing>}"
+              exit 1
+            fi
+          }
+
+          require_header_fragment() {
+            local header_name="$1"
+            local required_fragment="$2"
+            local actual_value
+            actual_value="$(get_header "$header_name")"
+
+            if [[ "$actual_value" != *"$required_fragment"* ]]; then
+              echo "Missing ${header_name} fragment: ${required_fragment}"
+              echo "Actual: ${actual_value:-<missing>}"
+              exit 1
+            fi
+          }
+
+          require_header_value "x-content-type-options" "nosniff"
+          require_header_value "referrer-policy" "strict-origin-when-cross-origin"
+
+          for permission in "camera=()" "microphone=()" "geolocation=()" "payment=()" "usb=()"; do
+            require_header_fragment "permissions-policy" "$permission"
+          done
+
+          for directive in \
+            "default-src 'self'" \
+            "base-uri 'self'" \
+            "object-src 'self'" \
+            "frame-ancestors 'none'" \
+            "script-src 'self' 'sha256-Gx10dm3GfPuh4U4BdlEImysQ7gQn3/l7ezIPDjQbD38=' https://www.googletagmanager.com" \
+            "connect-src 'self' https://formspree.io https://www.google-analytics.com https://*.google-analytics.com https://analytics.google.com https://*.analytics.google.com" \
+            "img-src 'self' data: https://www.googletagmanager.com https://www.google-analytics.com https://*.google-analytics.com" \
+            "style-src 'self' 'unsafe-inline'" \
+            "font-src 'self' data:" \
+            "form-action 'self' https://formspree.io" \
+            "frame-src 'self'" \
+            "upgrade-insecure-requests"; do
+            require_header_fragment "content-security-policy" "$directive"
+          done
+
+          echo "Production security headers match expected policy."

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -1,0 +1,47 @@
+name: npm audit
+
+"on":
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "main/package.json"
+      - "main/package-lock.json"
+      - ".github/workflows/npm-audit.yml"
+  schedule:
+    - cron: "18 14 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: npm-audit-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    name: Audit npm dependencies
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: main
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.13.0
+          cache: npm
+          cache-dependency-path: main/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run npm audit
+        run: npm audit --audit-level=moderate

--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ When `VITE_GA_MEASUREMENT_ID` is set, the app loads Google Analytics with manual
 
 Recommended GA4 key events are documented in [docs/analytics.md](./docs/analytics.md). The highest-signal candidates are `resume_download`, `contact_form_success`, `project_source_click`, and `case_study_link_click`.
 
+## Security Automation
+
+Lightweight GitHub-side checks cover Dependabot updates, npm audit, the existing CodeQL/default setup, secret scanning settings, and deployed security-header verification. Setup and ownership notes are documented in [docs/security-automation.md](./docs/security-automation.md).
+
 ## Deployment
 
 The site is deployed on Netlify using [netlify.toml](./netlify.toml):

--- a/docs/security-automation.md
+++ b/docs/security-automation.md
@@ -1,0 +1,40 @@
+# Security Automation
+
+Lightweight GitHub checks run alongside Codex and code review. They cover dependency freshness, npm vulnerability auditing, existing CodeQL analysis, secret scanning settings, and deployed security-header drift.
+
+## Repo-Owned Checks
+
+| Check | File | Cadence | Notes |
+| --- | --- | --- | --- |
+| Dependabot | `.github/dependabot.yml` | Weekly Monday | Opens grouped npm PRs for `/main` and grouped GitHub Actions update PRs. |
+| npm audit | `.github/workflows/npm-audit.yml` | Dependency PRs, weekly, manual | Runs `npm ci` and `npm audit --audit-level=moderate` in `main/`. |
+| Deployed headers | `.github/workflows/deployed-security-headers.yml` | Weekly, manual | Checks `https://waffy.dev/` for the expected CSP, X-Content-Type-Options, Referrer-Policy, and Permissions-Policy headers. |
+
+## GitHub Settings Checklist
+
+Secret scanning is enabled from GitHub repository settings, not from a workflow file. Keep these repository security features enabled:
+
+- Secret scanning
+- Push protection for secret scanning
+- Dependabot alerts
+- Dependabot security updates
+- Code scanning alerts with the existing CodeQL default setup enabled for JavaScript and TypeScript
+
+To verify the secret scanning settings, open the repository on GitHub, then go to **Settings > Advanced Security**. Enable **Secret Protection**, then enable **Push protection** inside the Secret Protection section.
+
+CodeQL is already running through GitHub code scanning/default setup. Keep that existing setup enabled instead of adding a checked-in `.github/workflows/codeql.yml`, unless the default setup is disabled first. Running both would duplicate CodeQL analysis on pull requests.
+
+For private or internal repositories, availability can depend on repository plan and GitHub security-product settings. These settings do not require any new repository secrets.
+
+Reference:
+
+- [Enable secret scanning](https://docs.github.com/en/code-security/how-tos/secure-your-secrets/detect-secret-leaks/enable-secret-scanning)
+- [Enable push protection](https://docs.github.com/en/code-security/how-tos/secure-your-secrets/prevent-future-leaks/enable-push-protection)
+- [Dependabot options reference](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference)
+- [CodeQL query suites](https://docs.github.com/en/code-security/concepts/code-scanning/codeql/codeql-query-suites)
+
+## Header Verification Notes
+
+`netlify.toml` remains the source of truth for production security headers. If the CSP in `netlify.toml` changes, update `.github/workflows/deployed-security-headers.yml` in the same change so the scheduled probe checks the deployed policy that should be live.
+
+The deployed-header workflow intentionally runs against production, so it is scheduled and manual only. Use the manual run after security-header changes have deployed.


### PR DESCRIPTION
## Summary
- Add Dependabot configuration for `/main` npm dependencies and GitHub Actions updates.
- Add scheduled/manual workflows for npm audit and deployed security-header verification.
- Document GitHub-owned security settings, including secret scanning, push protection, Dependabot alerts, and the existing CodeQL/default setup.

## Verification
- `git diff --check`
- YAML parse for `.github/**/*.yml` and `.github/**/*.yaml`
- `bash -n` for the deployed security-header workflow script block
- `node .codex/skills/csp-security-header-maintainer/scripts/check_csp_jsonld_hash.mjs /Users/waffyahmed/Downloads/personalWebsite`
- `npm audit --audit-level=moderate` currently fails on existing advisories in `@babel/core`, `esbuild`, `js-yaml`, `react-router`/`react-router-dom`, `undici`, and `vite`
- Pre-push hook passed `npm run lint`, `npm test`, and `npm run build`
- Live `curl -I https://waffy.dev/` returned HTTP 200 with the expected CSP, X-Content-Type-Options, Referrer-Policy, and Permissions-Policy headers

## Notes
- A checked-in CodeQL workflow is intentionally not included because CodeQL is already running through GitHub code scanning/default setup. Keeping both would duplicate CodeQL analysis on pull requests.
- Dependency upgrades are left out of this PR so the automation change stays focused; Dependabot/npm audit will surface the current advisory work separately.