### PR TITLE
Return real 404 responses

### DIFF
--- a/main/README.md
+++ b/main/README.md
@@ -44,4 +44,4 @@ Set `VITE_GA_MEASUREMENT_ID` to enable Google Analytics. The app sends manual SP
 - Static public assets live in `public/`.
 - `public/sitemap.xml`, `public/robots.txt`, `public/llms.txt`, `public/ai-summary.txt`, and `public/portfolio.json` support search and AI-agent discovery.
 - The resume route shows a PNG resume preview while preserving direct PDF open/download links.
-- `_redirects` keeps React Router routes working on Netlify.
+- `_redirects` rewrites canonical React Router routes on Netlify while unknown paths fall through to a real `404.html` response.

--- a/main/public/404.html
+++ b/main/public/404.html
@@ -1,0 +1,108 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#0B1220" />
+    <meta name="robots" content="noindex, nofollow" />
+    <meta
+      name="description"
+      content="The requested portfolio page could not be found. Return to Waffy Ahmed's software engineering portfolio."
+    />
+    <link rel="canonical" href="https://waffy.dev/" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="apple-touch-icon" href="/logo192.png" />
+    <title>Page Not Found | Waffy Ahmed</title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: Cambria, Georgia, serif;
+        background: #f4f1ea;
+        color: #0b1220;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        min-height: 100vh;
+        margin: 0;
+        display: grid;
+        place-items: center;
+        padding: 32px 18px;
+        background: #f4f1ea;
+      }
+
+      main {
+        width: min(100%, 42rem);
+        border: 1px solid rgba(15, 23, 42, 0.16);
+        border-radius: 8px;
+        background: rgba(255, 255, 255, 0.86);
+        padding: clamp(28px, 6vw, 48px);
+        text-align: center;
+        box-shadow: 0 24px 70px rgba(15, 23, 42, 0.12);
+      }
+
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 999px;
+        border: 1px solid rgba(194, 65, 12, 0.22);
+        background: #ffedd5;
+        color: #9a3412;
+        font: 700 0.75rem/1.2 Arial, sans-serif;
+        letter-spacing: 0;
+        padding: 0.45rem 0.75rem;
+        text-transform: uppercase;
+      }
+
+      h1 {
+        margin: 1.25rem 0 0;
+        font-size: 3.5rem;
+        line-height: 1;
+      }
+
+      p {
+        margin: 1rem auto 0;
+        max-width: 32rem;
+        color: #475569;
+        font: 1.125rem/1.65 Arial, sans-serif;
+      }
+
+      a {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 44px;
+        margin-top: 1.5rem;
+        border-radius: 8px;
+        background: #0b1220;
+        color: #ffffff;
+        font: 700 0.95rem/1 Arial, sans-serif;
+        padding: 0.85rem 1.15rem;
+        text-decoration: none;
+      }
+
+      a:focus-visible {
+        outline: 3px solid #2563eb;
+        outline-offset: 4px;
+      }
+
+      @media (max-width: 640px) {
+        h1 {
+          font-size: 2.4rem;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <span class="badge">404</span>
+      <h1>Page not found</h1>
+      <p>That route is outside the portfolio map, but the main site is ready.</p>
+      <a href="/">Go home</a>
+    </main>
+  </body>
+</html>

--- a/main/public/_redirects
+++ b/main/public/_redirects
@@ -3,4 +3,24 @@ http://waffy.netlify.app/* https://waffy.dev/:splat 301!
 https://www.waffy.dev/* https://waffy.dev/:splat 301!
 http://www.waffy.dev/* https://waffy.dev/:splat 301!
 /waffyahmedresume.pdf /waffyAhmedResume.pdf 301
-/* /index.html 200
+
+# Legacy app routes.
+/Resume /resume 301
+/Contact /contact 301
+/CaseStudies /case-studies 301
+/Case-Studies /case-studies 301
+/Experience /experience 301
+/Projects /projects 301
+
+# Canonical React app routes.
+/case-studies /index.html 200
+/case-studies/kubernetes-autoscaling /index.html 200
+/case-studies/legacy-deployment-recovery /index.html 200
+/case-studies/cdc-data-reconciliation /index.html 200
+/experience /index.html 200
+/projects /index.html 200
+/resume /index.html 200
+/contact /index.html 200
+
+# Unknown paths should return a real 404 instead of the SPA shell.
+/* /404.html 404

--- a/main/public/ai-summary.txt
+++ b/main/public/ai-summary.txt
@@ -271,9 +271,10 @@ React Router and publishes the following primary routes:
   text resources.
 
 Legacy uppercase routes such as /Resume, /Projects, /Experience, and /Contact
-redirect to lowercase routes in the React app. Netlify redirects also preserve
-single-page application routing and redirect /waffyahmedresume.pdf to the
-canonical /waffyAhmedResume.pdf path.
+redirect to lowercase routes in the React app and at the Netlify routing layer.
+Netlify rewrites canonical portfolio routes to the React shell, redirects
+/waffyahmedresume.pdf to the canonical /waffyAhmedResume.pdf path, and serves
+unknown paths through a static 404.html response with noindex metadata.
 
 Frontend Implementation Context:
 

--- a/main/src/App.test.jsx
+++ b/main/src/App.test.jsx
@@ -5,6 +5,7 @@ import { MemoryRouter } from "react-router-dom"
 import { readFileSync } from "node:fs"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import App from "./App.jsx"
+import { routeMetadata } from "./data/seo.js"
 
 const formspreeSubmitMock = vi.hoisted(() =>
   vi.fn((event) => event?.preventDefault?.())
@@ -466,7 +467,7 @@ describe("App routes", () => {
     )
   })
 
-  it("renders a not found route", () => {
+  it("renders a not found route with non-indexable metadata", async () => {
     renderRoute("/missing-page")
 
     expect(
@@ -475,6 +476,42 @@ describe("App routes", () => {
     expect(screen.getByRole("link", { name: /go home/i })).toHaveAttribute(
       "href",
       "/"
+    )
+    await waitFor(() =>
+      expect(document.title).toBe("Page Not Found | Waffy Ahmed")
+    )
+    expect(document.querySelector('meta[name="robots"]')).toHaveAttribute(
+      "content",
+      "noindex, nofollow"
+    )
+    expect(document.querySelector('link[rel="canonical"]')).toHaveAttribute(
+      "href",
+      "https://waffy.dev/"
+    )
+  })
+
+  it("publishes Netlify redirects for app routes and a real 404", () => {
+    const redirectLines = readFileSync("public/_redirects", "utf8")
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line && !line.startsWith("#"))
+
+    expect(redirectLines).not.toContain("/* /index.html 200")
+    routeMetadata
+      .filter((route) => route.path !== "/")
+      .forEach((route) => {
+        expect(redirectLines).toContain(`${route.path} /index.html 200`)
+      })
+    expect(redirectLines).toContain("/Projects /projects 301")
+    expect(redirectLines.at(-1)).toBe("/* /404.html 404")
+
+    const notFoundHtml = readFileSync("public/404.html", "utf8")
+
+    expect(notFoundHtml).toContain(
+      '<meta name="robots" content="noindex, nofollow" />'
+    )
+    expect(notFoundHtml).toContain(
+      '<link rel="canonical" href="https://waffy.dev/" />'
     )
   })
 

--- a/main/src/components/Seo.jsx
+++ b/main/src/components/Seo.jsx
@@ -35,8 +35,9 @@ function Seo() {
 
   useEffect(() => {
     const metadata = getRouteMetadata(location.pathname)
-    const canonicalUrl = toAbsoluteUrl(location.pathname)
+    const canonicalUrl = toAbsoluteUrl(metadata.canonicalPath ?? location.pathname)
     const imageUrl = toAbsoluteUrl(siteMetadata.imagePath)
+    const robots = metadata.robots ?? "index, follow"
 
     document.title = metadata.title
 
@@ -56,6 +57,10 @@ function Seo() {
     upsertMeta('meta[name="keywords"]', {
       name: "keywords",
       content: siteMetadata.keywords.join(", "),
+    })
+    upsertMeta('meta[name="robots"]', {
+      name: "robots",
+      content: robots,
     })
     upsertMeta('meta[property="og:url"]', {
       property: "og:url",

--- a/main/src/data/seo.js
+++ b/main/src/data/seo.js
@@ -72,6 +72,8 @@ export const defaultRouteMetadata = {
   title: "Page Not Found | Waffy Ahmed",
   description:
     "The requested portfolio page could not be found. Return to Waffy Ahmed's software engineering portfolio.",
+  canonicalPath: "/",
+  robots: "noindex, nofollow",
 }
 
 export const getRouteMetadata = (pathname) =>


### PR DESCRIPTION
## Summary
- Replace the global SPA catch-all rewrite with explicit Netlify rewrites for canonical portfolio routes.
- Add Netlify-level legacy uppercase redirects and a final `/* /404.html 404` rule for unknown paths.
- Add a static `404.html` with `noindex, nofollow` metadata and canonical homepage URL.
- Update client-side not-found SEO metadata, tests, README, and AI summary routing notes.

## Verification
- `bash .codex/skills/portfolio-release-qa/scripts/portfolio_preflight.sh /Users/waffyahmed/Downloads/personalWebsite`
- `node .codex/skills/seo-spa-auditor/scripts/check_spa_seo.mjs /Users/waffyahmed/Downloads/personalWebsite`
- `node .codex/skills/ai-discovery-maintainer/scripts/check_ai_discovery.mjs /Users/waffyahmed/Downloads/personalWebsite`
- `node .codex/skills/csp-security-header-maintainer/scripts/check_csp_jsonld_hash.mjs /Users/waffyahmed/Downloads/personalWebsite`
- `node .codex/skills/portfolio-content-sync/scripts/check_content_sync.mjs /Users/waffyahmed/Downloads/personalWebsite`
- `git diff --check`
- Static Netlify route smoke check for canonical rewrites, legacy redirects, no soft-404 catch-all, and final real 404 rule
- Confirmed `main/dist/404.html` and `main/dist/_redirects` are present after build
- Pre-push hook reran lint, tests, and production build successfully

## Notes
- Vite preview does not faithfully simulate Netlify `_redirects` response statuses. After deployment, verify an unknown URL returns HTTP 404 and canonical routes still return HTTP 200 on the deployed Netlify URL.