### PR TITLE
Pre-render route metadata shells

### DIFF
--- a/.codex/skills/portfolio-content-sync/scripts/check_content_sync.mjs
+++ b/.codex/skills/portfolio-content-sync/scripts/check_content_sync.mjs
@@ -19,6 +19,7 @@ for (const rel of [
   "main/src/data/experience.js",
   "main/src/data/projects.js",
   "main/src/data/caseStudies.js",
+  "main/src/data/caseStudySeo.js",
   "main/src/data/seo.js",
   "main/public/portfolio.json",
   "main/public/ai-summary.txt",
@@ -30,7 +31,7 @@ for (const rel of [
 
 if (errors.length === 0) {
   const projectsSource = read("main/src/data/projects.js")
-  const caseStudiesSource = read("main/src/data/caseStudies.js")
+  const caseStudiesSource = read("main/src/data/caseStudySeo.js")
   const seoSource = read("main/src/data/seo.js")
   const portfolioText = read("main/public/portfolio.json")
   const portfolio = JSON.parse(portfolioText)
@@ -46,7 +47,7 @@ if (errors.length === 0) {
   for (const slug of caseSlugs) {
     if (!portfolioCaseSlugs.has(slug)) errors.push(`portfolio.json missing case study slug ${slug}`)
     if (!sitemap.includes(`/case-studies/${slug}`)) errors.push(`sitemap.xml missing /case-studies/${slug}`)
-    if (!seoSource.includes(`/case-studies/${slug}`) && !seoSource.includes("caseStudies.map")) {
+    if (!seoSource.includes(`/case-studies/${slug}`) && !seoSource.includes("caseStudySeoItems.map")) {
       errors.push(`seo.js does not appear to cover case-study slug ${slug}`)
     }
   }

--- a/.codex/skills/seo-spa-auditor/scripts/check_spa_seo.mjs
+++ b/.codex/skills/seo-spa-auditor/scripts/check_spa_seo.mjs
@@ -14,10 +14,10 @@ const app = read("main/src/App.jsx")
 const sitemap = read("main/public/sitemap.xml")
 const robots = read("main/public/robots.txt")
 const indexHtml = read("main/index.html")
-const caseStudies = read("main/src/data/caseStudies.js")
+const caseStudySeo = read("main/src/data/caseStudySeo.js")
 
 const literalRoutes = extract(seo, /path:\s*"([^"]+)"/g).filter((route) => route !== "*")
-const caseStudyRoutes = extract(caseStudies, /slug:\s*"([^"]+)"/g).map((slug) => `/case-studies/${slug}`)
+const caseStudyRoutes = extract(caseStudySeo, /slug:\s*"([^"]+)"/g).map((slug) => `/case-studies/${slug}`)
 const routes = unique([...literalRoutes, ...caseStudyRoutes])
 
 for (const route of routes) {

--- a/docs/personal-website-repository-audit.md
+++ b/docs/personal-website-repository-audit.md
@@ -3,9 +3,13 @@
 **Repository:** `waffy1901/personalWebsite`  
 **Baseline reviewed:** `main` at `4f05b954309f7f6117549fee9d9537eab8014367`  
 **Reconciled against:** PR #125 (`overhaul/v2`)  
+**Website creation date:** Sep 12, 2024 at 2:17 PM<br>
 **Audit scope:** React application, content and data modules, tests, dependencies, Netlify configuration, public metadata, security controls, and GitHub Actions.
 
-> This is a source and configuration audit, not a fresh browser-based Lighthouse or visual-regression run. Findings below are reconciled against the current PR so resolved items are not presented as open work.
+> This began as a source and configuration audit, not a browser-based Lighthouse
+> or visual-regression run. The post-deploy addendum records later live
+> production validation, and resolved items are marked as such where follow-up
+> PRs addressed them.
 
 ---
 
@@ -16,9 +20,65 @@ The portfolio is in **good engineering shape**. It presents a distinctive, recru
 No obvious build-breaking or critical security issue was found. The highest-value remaining work is architectural rather than cosmetic:
 
 1. Pre-render canonical routes so crawlers and link-preview clients receive route-specific metadata.
-2. Return genuine 404 responses for unknown URLs.
-3. Generate public documentation and AI-readable artifacts from canonical data to prevent drift.
-4. Add targeted accessibility, performance, and security hardening.
+2. Generate public documentation and AI-readable artifacts from canonical data to prevent drift.
+3. Add targeted accessibility, performance, and security hardening.
+
+---
+
+## Post-Deploy Validation Addendum
+
+- **Validation date:** Jun 30, 2026
+- **Production URL:** `https://waffy.dev/`
+- **Relevant follow-up PRs:** PR #127 (`feat/trust-metadata-a11y-polish`) and PR #128 (`feat/real-404-routing`)
+
+The deployed site remains user-functionally healthy after the trust, metadata,
+accessibility, security-header, and real-404 work:
+
+- Canonical app routes returned HTTP 200 and rendered in the browser: `/`,
+  `/projects`, `/experience`, `/case-studies`, all three case-study detail
+  routes, `/resume`, and `/contact`.
+- Unknown routes now return a genuine HTTP 404 and serve the static 404 page.
+  The deployed 404 HTML includes `noindex, nofollow` and canonicalizes to
+  `https://waffy.dev/`.
+- Legacy uppercase app routes such as `/Projects`, `/Resume`, `/Contact`,
+  `/Experience`, and `/CaseStudies` returned HTTP 301 to lowercase routes.
+- Resume, discovery, and metadata assets remained available: the canonical
+  resume PDF, resume preview image, Open Graph image, `llms.txt`,
+  `ai-summary.txt`, `portfolio.json`, `sitemap.xml`, `robots.txt`, and
+  `manifest.json`.
+- Browser checks confirmed key interaction flows still work: project detail
+  expansion, experience detail expansion, experience copy-status behavior,
+  resume preview/actions, contact form field rendering, case-study navigation,
+  and static 404 rendering.
+- Security headers were present on live HTML, 404, PDF, and static asset
+  responses, including CSP, HSTS, `X-Content-Type-Options`,
+  `Referrer-Policy`, and `Permissions-Policy`.
+
+Production validation also surfaced four follow-up findings:
+
+1. **Analytics CSP allowlist is incomplete.** Google Analytics still sends at
+   least some events successfully to `analytics.google.com`, but browser console
+   output shows GA also attempting `stats.g.doubleclick.net` and
+   `www.google.com/g/collect`, which the current `connect-src` blocks. This can
+   make analytics collection noisy or incomplete.
+2. **The lowercase legacy resume URL is functional but not canonical-clean.**
+   `/waffyahmedresume.pdf` serves the PDF with HTTP 200 instead of redirecting
+   to `/waffyAhmedResume.pdf`. Use a forced redirect if canonicalization matters:
+   `/waffyahmedresume.pdf /waffyAhmedResume.pdf 301!`.
+3. **Deep routes still publish homepage metadata in initial HTML.** Browser
+   titles and metadata update after React loads, but raw HTML for routes such as
+   `/projects`, `/experience`, and `/case-studies/kubernetes-autoscaling` still
+   contains homepage title, canonical, and Open Graph metadata. This confirms
+   prerendered route metadata remains the highest-value next architectural fix.
+4. **Mobile primary navigation is horizontally scrollable at narrow widths.**
+   At a 390px viewport, the nav strip remains functional, but the Contact link
+   starts off-screen until the nav is scrolled. This is not broken behavior, but
+   it is a small usability caveat for mobile visitors.
+
+The multi-agent validation attempt was partially limited by sandbox DNS access:
+several sub-agents could not resolve `waffy.dev`. The successful production
+evidence above came from the main validation pass with approved live network
+access and Playwright browser checks.
 
 ---
 
@@ -39,9 +99,25 @@ The current PR addresses several findings from the baseline review:
 
 These items should not be tracked as unresolved findings after this PR merges.
 
+## Resolved in PR #127 and PR #128
+
+Recent follow-up work addressed several additional findings from this audit:
+
+- Tightened risky or awkward project and experience wording.
+- Updated stale React/version and route-behavior documentation in README and
+  AI-readable summary surfaces.
+- Improved `ExperienceCard` accessibility with copy-status live announcements,
+  timeout cleanup, Escape-to-close behavior, focus restoration, and
+  reduced-motion handling.
+- Refreshed app manifest and theme metadata.
+- Hardened deployed security headers by using `object-src 'none'`,
+  `frame-src 'none'`, and adding HSTS.
+- Replaced the soft-404 SPA catch-all with explicit Netlify route rewrites and
+  a real static `404.html` response for unknown paths.
+
 ---
 
-# Open Findings
+# Findings and Follow-Up Work
 
 ## 1. High: Deep Routes Initially Publish Homepage Metadata
 
@@ -80,38 +156,35 @@ The route-level metadata definitions already exist; the missing step is publishi
 
 ---
 
-## 2. High: Unknown Routes Produce Soft 404s
+## 2. Resolved: Unknown Routes Previously Produced Soft 404s
 
-The catch-all SPA rewrite returns `index.html` with HTTP 200 for unknown URLs. React later renders the `NotFound` page, but the server response is still successful and the initial HTML remains indexable.
+The earlier catch-all SPA rewrite returned `index.html` with HTTP 200 for
+unknown URLs. React later rendered the `NotFound` page, but the server response
+was still successful and the initial HTML remained indexable.
 
-### Recommended Correction
+### Resolution
 
-Preferred approach:
-
-- Pre-render known routes.
-- Publish a real `404.html`.
-- Allow Netlify to return HTTP 404 for unknown paths.
-
-Interim improvement:
-
-- Apply `noindex, nofollow` on the client-rendered not-found route.
-- Canonicalize invalid paths back to the homepage rather than to the invalid URL.
+PR #128 published a static `404.html`, removed the global `/* /index.html 200`
+soft-404 catch-all, added explicit rewrites for canonical React routes, and
+allows unknown paths to return HTTP 404. Deployed validation confirmed
+`https://waffy.dev/definitely-missing-page` returns HTTP 404 with
+`noindex, nofollow` and homepage canonical metadata.
 
 **Relevant files:**
 
 - `main/public/_redirects`
 - `main/src/components/Seo.jsx`
 - `main/src/pages/NotFound.jsx`
+- `main/public/404.html`
 
 ---
 
 ## 3. High-Medium: Documentation and AI Artifacts Can Drift
 
-The root README correctly lists React 19, but two other public documentation surfaces are stale:
-
-- `main/README.md` still lists React 18.
-- `main/public/ai-summary.txt` still describes the implementation as React 18.
-- The AI summary says the homepage includes Georgia Tech branding, while the redesigned hero now centers the profile image and platform/reliability positioning.
+PR #127 corrected the known React-version and hero-description drift in
+`main/README.md` and `main/public/ai-summary.txt`. The broader risk remains:
+public documentation and AI-readable artifacts can still drift because several
+surfaces are maintained manually.
 
 The same career claims and metrics also appear across JavaScript data modules, JSON-LD, `portfolio.json`, `ai-summary.txt`, `llms.txt`, the sitemap, and both READMEs. Manual synchronization across these surfaces is likely to drift again.
 
@@ -148,9 +221,9 @@ Add synchronization tests covering framework versions, case-study slugs, primary
 
 ---
 
-## 4. Medium: A Few Content Claims Need Tighter Wording
+## 4. Resolved: A Few Content Claims Needed Tighter Wording
 
-The following wording remains worth revising:
+The baseline review flagged wording that was worth revising:
 
 - The 2024 internship bullet uses `germane product data` and `pruning customer theft`, which read unnaturally and imply stronger direct causality than the surrounding context establishes.
 - The release-governance section says staged rollouts ensure `zero regressions`; a rollout process can reduce risk but cannot guarantee that outcome.
@@ -166,6 +239,13 @@ Suggested direction:
 
 - `main/src/data/experience.js`
 - `main/src/data/projects.js`
+
+### Resolution
+
+PR #127 replaced these phrases with tighter wording around validated product
+information, loss-prevention support, regression-risk reduction, and exact Job
+Search Aid capabilities. The FirebaseAuth versus Firestore distinction was
+preserved.
 
 ---
 
@@ -213,11 +293,20 @@ A lightweight production bundle report is sufficient for now; Lighthouse CI beco
 
 # Accessibility and Interaction
 
-## 8. Low: Clipboard Results Are Visual Only
+## 8. Resolved: Clipboard Results Were Visual Only
 
-`ExperienceCard` visually shows `Copied`, `Copy failed`, or `Copy`, but the status is not announced through an `aria-live` region. The reset timeout should also be cleared if the component unmounts.
+`ExperienceCard` previously showed `Copied`, `Copy failed`, or `Copy`
+visually, but the status was not announced through an `aria-live` region. The
+reset timeout also needed cleanup if the component unmounted.
 
 **Relevant file:** `main/src/components/ExperienceCard.jsx`
+
+### Resolution
+
+PR #127 added a copy-status live region, timeout cleanup, Escape-to-close
+behavior, focus restoration, and reduced-motion handling. Post-deploy browser
+validation confirmed experience detail expansion and copy-status behavior still
+work.
 
 ### Existing Strengths
 
@@ -231,9 +320,10 @@ A lightweight production bundle report is sufficient for now; Lighthouse CI beco
 
 # Security and Privacy
 
-## 9. Medium-Low: CSP Can Be Hardened Further
+## 9. Resolved: CSP Could Be Hardened Further
 
-The existing Content Security Policy is substantially better than having no policy. Remaining defense-in-depth improvements include:
+The baseline Content Security Policy was substantially better than having no
+policy. Remaining defense-in-depth improvements included:
 
 - Change `object-src 'self'` to `object-src 'none'` if no object/embed content is required.
 - Change `frame-src 'self'` to `frame-src 'none'` if no embedded frame is required.
@@ -246,6 +336,18 @@ The deployed-header verification workflow should be updated alongside any policy
 
 - `netlify.toml`
 - `.github/workflows/deployed-security-headers.yml`
+
+### Resolution
+
+PR #127 changed `object-src` to `none`, changed `frame-src` to `none`, added
+HSTS, and updated deployed-header verification. Post-deploy validation confirmed
+the hardened headers are present on live HTML, 404, PDF, and static asset
+responses.
+
+The separate production finding from Jun 30, 2026 is not general CSP hardening:
+Google Analytics now attempts additional collection endpoints that are blocked
+by `connect-src`. Treat that as an analytics allowlist follow-up rather than a
+regression in the original hardening work.
 
 ---
 
@@ -278,7 +380,7 @@ This is future operational hardening, not a release blocker.
 
 # Metadata and Platform Polish
 
-## 12. Medium-Low: Manifest Metadata Uses the Previous Theme
+## 12. Resolved: Manifest Metadata Used the Previous Theme
 
 The redesigned site uses cream, navy, orange, and blue, while the manifest and HTML theme metadata still use generic black and white values.
 
@@ -297,6 +399,11 @@ The manifest name can also be changed from `Waffy's Website` to `Waffy Ahmed | S
 
 - `main/public/manifest.json`
 - `main/index.html`
+
+### Resolution
+
+PR #127 updated the manifest name, theme color, background color, and static
+HTML theme color.
 
 ---
 
@@ -323,7 +430,7 @@ The repository already has unusually mature automation for a personal portfolio:
 Recommended additions, in descending order of value:
 
 1. `axe` checks for every top-level route.
-2. A test proving not-found routes receive `noindex` until real 404s are implemented.
+2. A deployed-route smoke check proving unknown URLs return HTTP 404.
 3. Synchronization tests for sitemap, JSON-LD, AI artifacts, and framework versions.
 4. A rendered-HTML test confirming route-specific metadata after prerendering.
 5. One mobile and one desktop visual-regression pass.
@@ -356,12 +463,12 @@ That would make the case studies read more like senior engineering narratives an
 
 # Recommended Execution Order
 
-1. Pre-render canonical routes and implement genuine 404 responses.
+1. Pre-render canonical routes so initial HTML contains route-specific metadata.
 2. Generate public documentation and AI artifacts from canonical data.
-3. Correct the remaining wording and documentation drift.
-4. Add route-level lazy loading and explicit image-loading behavior.
-5. Add accessibility and performance regression checks.
-6. Harden response headers and add a concise privacy disclosure.
+3. Add route-level lazy loading and explicit image-loading behavior.
+4. Add accessibility and performance regression checks.
+5. Add a concise privacy disclosure and review Formspree spam controls.
+6. Address the Analytics CSP allowlist and lowercase resume canonicalization findings from the post-deploy validation.
 
 ---
 

--- a/main/package.json
+++ b/main/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "dev": "vite",
     "start": "vite",
-    "build": "VITE_DEPLOY_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ) VITE_SITE_URL=https://waffy.dev vite build",
+    "build": "VITE_DEPLOY_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ) VITE_SITE_URL=https://waffy.dev vite build && node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/prerender-route-metadata.mjs",
     "lint": "eslint src",
     "preview": "vite preview",
     "test": "vitest run"

--- a/main/public/_redirects
+++ b/main/public/_redirects
@@ -13,14 +13,14 @@ http://www.waffy.dev/* https://waffy.dev/:splat 301!
 /Projects /projects 301
 
 # Canonical React app routes.
-/case-studies /index.html 200
-/case-studies/kubernetes-autoscaling /index.html 200
-/case-studies/legacy-deployment-recovery /index.html 200
-/case-studies/cdc-data-reconciliation /index.html 200
-/experience /index.html 200
-/projects /index.html 200
-/resume /index.html 200
-/contact /index.html 200
+/case-studies /case-studies/index.html 200
+/case-studies/kubernetes-autoscaling /case-studies/kubernetes-autoscaling/index.html 200
+/case-studies/legacy-deployment-recovery /case-studies/legacy-deployment-recovery/index.html 200
+/case-studies/cdc-data-reconciliation /case-studies/cdc-data-reconciliation/index.html 200
+/experience /experience/index.html 200
+/projects /projects/index.html 200
+/resume /resume/index.html 200
+/contact /contact/index.html 200
 
 # Unknown paths should return a real 404 instead of the SPA shell.
 /* /404.html 404

--- a/main/scripts/prerender-route-metadata.mjs
+++ b/main/scripts/prerender-route-metadata.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+import { mkdir, readFile, writeFile } from "node:fs/promises"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import {
+  routeMetadata,
+  siteMetadata,
+  toAbsoluteUrl,
+} from "../src/data/seo.js"
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url))
+const appRoot = path.resolve(scriptDir, "..")
+const distDir = path.join(appRoot, "dist")
+const indexPath = path.join(distDir, "index.html")
+
+const escapeAttribute = (value) =>
+  String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+
+const escapeText = (value) =>
+  String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+
+const replaceRequired = (html, label, pattern, replacement) => {
+  if (!pattern.test(html)) {
+    throw new Error(`Missing required ${label} in dist/index.html`)
+  }
+
+  return html.replace(pattern, replacement)
+}
+
+const updateTitle = (html, title) =>
+  replaceRequired(
+    html,
+    "title element",
+    /<title>[\s\S]*?<\/title>/i,
+    `<title>${escapeText(title)}</title>`
+  )
+
+const updateMetaContent = (html, attributeName, attributeValue, content) => {
+  const tagPattern = new RegExp(
+    `<meta\\b(?=[^>]*\\b${attributeName}="${attributeValue}")[^>]*>`,
+    "i"
+  )
+  const match = html.match(tagPattern)
+
+  if (!match) {
+    throw new Error(
+      `Missing required meta ${attributeName}="${attributeValue}" in dist/index.html`
+    )
+  }
+
+  const [tag] = match
+  if (!/\bcontent="[^"]*"/i.test(tag)) {
+    throw new Error(
+      `Missing content attribute on meta ${attributeName}="${attributeValue}"`
+    )
+  }
+
+  return html.replace(
+    tag,
+    tag.replace(/\bcontent="[^"]*"/i, `content="${escapeAttribute(content)}"`)
+  )
+}
+
+const updateLinkHref = (html, rel, href) => {
+  const tagPattern = new RegExp(
+    `<link\\b(?=[^>]*\\brel="${rel}")[^>]*>`,
+    "i"
+  )
+  const match = html.match(tagPattern)
+
+  if (!match) {
+    throw new Error(`Missing required link rel="${rel}" in dist/index.html`)
+  }
+
+  const [tag] = match
+  if (!/\bhref="[^"]*"/i.test(tag)) {
+    throw new Error(`Missing href attribute on link rel="${rel}"`)
+  }
+
+  return html.replace(
+    tag,
+    tag.replace(/\bhref="[^"]*"/i, `href="${escapeAttribute(href)}"`)
+  )
+}
+
+const validateRoute = (route) => {
+  if (!route.path || !route.path.startsWith("/")) {
+    throw new Error(`Invalid route metadata path: ${route.path}`)
+  }
+
+  if (!route.title) {
+    throw new Error(`Missing title for route ${route.path}`)
+  }
+
+  if (!route.description) {
+    throw new Error(`Missing description for route ${route.path}`)
+  }
+}
+
+const renderRouteHtml = (templateHtml, route) => {
+  validateRoute(route)
+
+  const canonicalUrl = toAbsoluteUrl(route.path)
+  const imageUrl = toAbsoluteUrl(siteMetadata.imagePath)
+
+  let html = templateHtml
+  html = updateTitle(html, route.title)
+  html = updateLinkHref(html, "canonical", canonicalUrl)
+  html = updateMetaContent(html, "name", "description", route.description)
+  html = updateMetaContent(html, "name", "author", siteMetadata.author)
+  html = updateMetaContent(html, "name", "keywords", siteMetadata.keywords.join(", "))
+  html = updateMetaContent(html, "property", "og:url", canonicalUrl)
+  html = updateMetaContent(html, "property", "og:title", route.title)
+  html = updateMetaContent(html, "property", "og:description", route.description)
+  html = updateMetaContent(html, "property", "og:image", imageUrl)
+  html = updateMetaContent(html, "property", "og:image:secure_url", imageUrl)
+  html = updateMetaContent(html, "name", "twitter:title", route.title)
+  html = updateMetaContent(html, "name", "twitter:description", route.description)
+  html = updateMetaContent(html, "name", "twitter:image", imageUrl)
+
+  return html
+}
+
+const routeOutputPaths = (routePath) => {
+  if (routePath === "/") {
+    return [indexPath]
+  }
+
+  const relativeRoute = routePath.replace(/^\//, "")
+
+  return [path.join(distDir, relativeRoute, "index.html")]
+}
+
+const writeRouteHtml = async (route, html) => {
+  for (const outputPath of routeOutputPaths(route.path)) {
+    await mkdir(path.dirname(outputPath), { recursive: true })
+    await writeFile(outputPath, html)
+  }
+}
+
+const run = async () => {
+  if (routeMetadata.length === 0) {
+    throw new Error("No route metadata found")
+  }
+
+  const templateHtml = await readFile(indexPath, "utf8")
+
+  for (const route of routeMetadata) {
+    await writeRouteHtml(route, renderRouteHtml(templateHtml, route))
+  }
+
+  console.log(`Pre-rendered metadata shells for ${routeMetadata.length} routes`)
+}
+
+run().catch((error) => {
+  console.error(error.message)
+  process.exit(1)
+})

--- a/main/src/App.test.jsx
+++ b/main/src/App.test.jsx
@@ -500,7 +500,9 @@ describe("App routes", () => {
     routeMetadata
       .filter((route) => route.path !== "/")
       .forEach((route) => {
-        expect(redirectLines).toContain(`${route.path} /index.html 200`)
+        expect(redirectLines).toContain(
+          `${route.path} ${route.path}/index.html 200`
+        )
       })
     expect(redirectLines).toContain("/Projects /projects 301")
     expect(redirectLines.at(-1)).toBe("/* /404.html 404")

--- a/main/src/data/caseStudies.js
+++ b/main/src/data/caseStudies.js
@@ -1,5 +1,10 @@
 import cdcLogo from "../images/cdcLogo.png"
 import hdLogo from "../images/hdLogo.png"
+import {
+  cdcDataReconciliationSeo,
+  kubernetesAutoscalingSeo,
+  legacyDeploymentRecoverySeo,
+} from "./caseStudySeo.js"
 
 export const caseStudiesPage = {
   title: "Selected engineering case studies",
@@ -26,15 +31,12 @@ export const caseStudiesPage = {
 
 export const caseStudies = [
   {
-    slug: "kubernetes-autoscaling",
-    title: "Kubernetes Autoscaling for Transaction-Critical Services",
+    ...kubernetesAutoscalingSeo,
     organization: "The Home Depot",
     timeframe: "2025",
     category: "Platform Reliability",
     logo: hdLogo,
     logoTheme: "home-depot",
-    summary:
-      "Validated and deployed Horizontal Pod Autoscaling (HPA) for a high-throughput service previously capped at static capacity, improving latency, errors, throughput, and CPU efficiency under production traffic.",
     metrics: [
       {
         value: "40%",
@@ -113,15 +115,12 @@ export const caseStudies = [
     ],
   },
   {
-    slug: "legacy-deployment-recovery",
-    title: "Legacy Deployment Recovery and Credential Rotation",
+    ...legacyDeploymentRecoverySeo,
     organization: "The Home Depot",
     timeframe: "2026",
     category: "Deployment Automation",
     logo: hdLogo,
     logoTheme: "home-depot",
-    summary:
-      "Rebuilt deployment workflows for abandoned Java 1.8 Tomcat services so mission-critical repositories could support zero-downtime Cassandra credential rotation.",
     metrics: [
       {
         value: "8",
@@ -200,15 +199,12 @@ export const caseStudies = [
     ],
   },
   {
-    slug: "cdc-data-reconciliation",
-    title: "CDC Data Reconciliation Platform",
+    ...cdcDataReconciliationSeo,
     organization: "Centers for Disease Control and Prevention",
     timeframe: "2023-2024",
     category: "Full-Stack Data Systems",
     logo: cdcLogo,
     logoTheme: "cdc",
-    summary:
-      "Led a team of six building a full-stack reconciliation platform for infectious disease case-count discrepancies between state health departments and CDC datasets.",
     metrics: [
       {
         value: "5000+",

--- a/main/src/data/caseStudySeo.js
+++ b/main/src/data/caseStudySeo.js
@@ -1,0 +1,26 @@
+export const kubernetesAutoscalingSeo = {
+  slug: "kubernetes-autoscaling",
+  title: "Kubernetes Autoscaling for Transaction-Critical Services",
+  summary:
+    "Validated and deployed Horizontal Pod Autoscaling (HPA) for a high-throughput service previously capped at static capacity, improving latency, errors, throughput, and CPU efficiency under production traffic.",
+}
+
+export const legacyDeploymentRecoverySeo = {
+  slug: "legacy-deployment-recovery",
+  title: "Legacy Deployment Recovery and Credential Rotation",
+  summary:
+    "Rebuilt deployment workflows for abandoned Java 1.8 Tomcat services so mission-critical repositories could support zero-downtime Cassandra credential rotation.",
+}
+
+export const cdcDataReconciliationSeo = {
+  slug: "cdc-data-reconciliation",
+  title: "CDC Data Reconciliation Platform",
+  summary:
+    "Led a team of six building a full-stack reconciliation platform for infectious disease case-count discrepancies between state health departments and CDC datasets.",
+}
+
+export const caseStudySeoItems = [
+  kubernetesAutoscalingSeo,
+  legacyDeploymentRecoverySeo,
+  cdcDataReconciliationSeo,
+]

--- a/main/src/data/profile.js
+++ b/main/src/data/profile.js
@@ -1,8 +1,11 @@
 import gtLogo from "../images/gtLogo.png"
 import profilePicture from "../images/profilePic.jpg"
+import { portfolioUrls, profileIdentity } from "./siteIdentity.js"
+
+export { portfolioUrls }
 
 export const profile = {
-  name: "Waffy Ahmed",
+  name: profileIdentity.name,
   tagline: "Software Engineer | Georgia Tech",
   intro:
     "I'm a Software Engineer at The Home Depot, owning operational health across 60+ repositories that support transaction-critical services. My work focuses on Kubernetes autoscaling, deployment automation, observability, and incident response for high-throughput systems processing millions of transactions daily. Previously, I interned at The Home Depot twice and led a team of six building a data reconciliation platform for the CDC. I'm a Georgia Tech graduate focused on reliability engineering and building systems that don\u2019t page you at 2 AM.",
@@ -44,9 +47,4 @@ export const socialLinks = [
 
 export const deployInfo = {
   firstPublishedAt: "2024-09-13T19:43:00Z",
-}
-
-export const portfolioUrls = {
-  site: "https://waffy.dev",
-  aiSummary: "https://waffy.dev/ai-summary.txt",
 }

--- a/main/src/data/seo.js
+++ b/main/src/data/seo.js
@@ -1,5 +1,5 @@
-import { caseStudies } from "./caseStudies"
-import { portfolioUrls, profile } from "./profile"
+import { caseStudySeoItems } from "./caseStudySeo.js"
+import { portfolioUrls, profileIdentity } from "./siteIdentity.js"
 
 const defaultDescription =
   "Software engineering portfolio for Waffy Ahmed, focused on reliability, Kubernetes, deployment automation, observability, and high-throughput systems."
@@ -10,7 +10,7 @@ export const siteMetadata = {
   defaultTitle: "Waffy Ahmed | Software Engineer Portfolio",
   defaultDescription,
   imagePath: "/og-image.png",
-  author: profile.name,
+  author: profileIdentity.name,
   keywords: [
     "Waffy Ahmed",
     "software engineer",
@@ -37,7 +37,7 @@ export const routeMetadata = [
     description:
       "Engineering case studies covering Kubernetes autoscaling, legacy deployment recovery, and CDC data reconciliation work.",
   },
-  ...caseStudies.map((caseStudy) => ({
+  ...caseStudySeoItems.map((caseStudy) => ({
     path: `/case-studies/${caseStudy.slug}`,
     title: `${caseStudy.title} | Waffy Ahmed`,
     description: caseStudy.summary,

--- a/main/src/data/siteIdentity.js
+++ b/main/src/data/siteIdentity.js
@@ -1,0 +1,8 @@
+export const profileIdentity = {
+  name: "Waffy Ahmed",
+}
+
+export const portfolioUrls = {
+  site: "https://waffy.dev",
+  aiSummary: "https://waffy.dev/ai-summary.txt",
+}


### PR DESCRIPTION
## Summary
- Add a post-build prerender step that emits route-specific static HTML metadata shells from canonical `routeMetadata`.
- Split SEO-safe site identity and case-study route data away from image-importing modules so Node can import metadata after Vite builds.
- Point canonical Netlify app-route rewrites at the matching prerendered shells and update route/SEO sync checks and tests.
- Update the repository audit doc with the post-deploy validation addendum and resolved follow-up context.

## Verification
- `bash .codex/skills/portfolio-release-qa/scripts/portfolio_preflight.sh /Users/waffyahmed/Downloads/personalWebsite`
- `node .codex/skills/seo-spa-auditor/scripts/check_spa_seo.mjs /Users/waffyahmed/Downloads/personalWebsite`
- `node .codex/skills/portfolio-content-sync/scripts/check_content_sync.mjs /Users/waffyahmed/Downloads/personalWebsite`
- `git diff --check`
- `git diff --staged --check`
- Generated artifact sweep confirmed canonical route `index.html` shells are emitted and non-canonical `*.html` route aliases are not emitted.
- Outside-sandbox Netlify dev curl matrix confirmed canonical routes return route-specific initial metadata, `.html` aliases return 404, missing pages return 404/noindex, and public assets return 200.
- Live Netlify edge curls confirmed `/Projects` and `/Resume` still 301 to lowercase canonical routes.

## Notes
- Current live production still serves `/waffyahmedresume.pdf` with HTTP 200 instead of redirecting to `/waffyAhmedResume.pdf`; this is a separate existing canonicalization follow-up noted in the audit doc.