### PR TITLE
Improve portfolio performance and release verification

### DIFF
--- a/.codex/skills/adversarial-change-verifier/SKILL.md
+++ b/.codex/skills/adversarial-change-verifier/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: adversarial-change-verifier
+description: Orchestrate adversarial, multi-agent regression verification for Waffy Ahmed's personalWebsite. Use when Codex is asked to spin up agents, run a team of agents, adversarially verify new or uncommitted changes, check regressions, validate all functionality, compare local or deploy-preview behavior against production, or perform broad post-change QA across routes, SEO, content, AI discovery, resume assets, analytics, CSP/security headers, visual layout, and deployed site behavior.
+---
+
+# Adversarial Change Verifier
+
+## Core Workflow
+
+1. Establish scope and safety.
+   - Check `git status --short` before edits or verification.
+   - Identify the target: uncommitted diff, branch, PR, local build, deploy preview, production, or a comparison between them.
+   - Treat unrelated changes as user-owned. Stay in verification mode unless the user asks to fix, document, commit, push, or deploy.
+   - If live browser QA is in scope, tell the user it can count as GA4 traffic. `curl`, Node HTTP checks, GitHub automation, and package audits do not run the site in a browser and should not affect GA4.
+
+2. Load adjacent repo skills only when their surfaces are in scope.
+   - Use `$portfolio-release-qa` for release readiness, lint/test/build, preview smoke checks, static assets, or Netlify deploy readiness.
+   - Use `$seo-spa-auditor` for routes, redirects, canonical URLs, sitemap, robots, Open Graph/Twitter metadata, prerender shells, or SPA route behavior.
+   - Use `$portfolio-content-sync` for profile, experience, projects, case studies, metrics, recruiter copy, route slugs, or public metadata.
+   - Use `$ai-discovery-maintainer` for `llms.txt`, `ai-summary.txt`, `portfolio.json`, JSON-LD, structured data, or AI-agent guidance.
+   - Use `$resume-site-sync` for resume PDF links, preview image, resume route behavior, or canonical resume assets.
+   - Use `$csp-security-header-maintainer` for CSP, security headers, JSON-LD hashes, GA/Formspree allowlists, redirects, frames, or third-party connections.
+   - Use `$ga4-portfolio-analytics` for GA4 events, page tracking, key-event candidates, or analytics tests.
+   - Use `$portfolio-performance-auditor` for route splitting, image loading priority, asset delivery, layout stability, or Vite bundle output.
+   - Use `$portfolio-audit-maintainer` for `docs/personal-website-repository-audit.md`, deployed evidence, finding classification, or audit provenance.
+   - Use `$portfolio-github-automation-maintainer` for GitHub Actions workflows, Dependabot, CodeQL, deployed-header automation, or workflow-run behavior.
+
+3. Build a lane plan from the diff and the user's wording.
+   - Read [references/verification-lanes.md](references/verification-lanes.md) and select the smallest set of lanes that covers the risk.
+   - For "all functionality", "fully functional", "regressions", or "spin up agents", run multiple independent lanes rather than one broad smoke test.
+   - Prefer adversarial questions: what could this break, what changed indirectly, what route or asset would a crawler see first, what user action emits telemetry, what deploy-only behavior differs from local?
+
+4. Use independent agents when available.
+   - If multi-agent tools are available, search for them and spawn read-only agents with narrow prompts, raw artifacts, and no expected answer.
+   - Give each agent one lane, such as diff-risk mapping, route/functionality smoke, SEO/crawler checks, content/AI/resume consistency, analytics/CSP/security review, visual/browser QA, or deployed HTTP verification.
+   - Ask each agent for exact evidence, commands, routes, confidence, and residual risk. Do not ask agents to modify files unless the user explicitly requests fixes.
+   - If subagents are unavailable, run the same lanes sequentially and keep the notes separated.
+
+5. Verify with evidence.
+   - Run the narrowest meaningful checks first, then broaden to `npm run lint`, `npm run test`, and `npm run build` as risk requires.
+   - Use repo checkers from the adjacent skills when public content, SEO, AI discovery, resume assets, analytics, CSP, or release readiness are in scope.
+   - For deployed checks, use authoritative URLs from production or the deploy preview. Do not treat local preview evidence as proof of live behavior.
+   - For 404 checks, avoid `curl -f` so the body remains available for `noindex, nofollow` verification.
+
+6. Report like a review.
+   - Lead with findings ordered by severity, with file/route/command evidence.
+   - Separate true regressions from caveats and nitpicks in practical language.
+   - If no issues are found, say so clearly and mention remaining test gaps or live checks not run.
+   - Include commands run, checks skipped, and whether live browser QA may have affected GA4.
+   - If deployed findings must persist, update the repo audit artifact only when the user asks or the task explicitly includes audit documentation.

--- a/.codex/skills/adversarial-change-verifier/agents/openai.yaml
+++ b/.codex/skills/adversarial-change-verifier/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Adversarial Change Verifier"
+  short_description: "Parallel regression and change verification"
+  default_prompt: "Use $adversarial-change-verifier to spin up agents and adversarially verify my latest portfolio changes."

--- a/.codex/skills/adversarial-change-verifier/references/verification-lanes.md
+++ b/.codex/skills/adversarial-change-verifier/references/verification-lanes.md
@@ -1,0 +1,163 @@
+# Verification Lanes
+
+Use these lanes as reusable building blocks. Select by changed files, user wording, and deployment target.
+
+## Inputs To Collect
+
+- `git status --short`
+- `git diff --stat` and `git diff --name-only`
+- Staged diff if relevant: `git diff --cached --stat` and `git diff --cached --name-only`
+- Target URLs: local dev, local preview, deploy preview, production, or comparison pair
+- Changed public surfaces: routes, data files, static assets, redirects, headers, workflows, analytics, forms, and tests
+
+## Lane 1: Diff-Risk Mapper
+
+Goal: identify what could regress before running checks.
+
+Inspect changed files and map them to surfaces:
+
+- `main/src/data/*`: visible content, public metadata, route slugs, SEO alignment, AI discovery alignment
+- `main/src/pages/*` or `main/src/components/*`: route behavior, layout, accessibility, navigation, analytics call sites
+- `main/src/App.jsx` or router changes: canonical routes, legacy uppercase redirects, 404 behavior, route smoke tests
+- `main/public/*`: static assets, resume paths, discovery docs, sitemap, robots, redirects, manifest
+- `main/index.html` or JSON-LD: CSP hash, structured data, crawler-visible profile data
+- `netlify.toml`: headers, redirects, CSP, Formspree/GA allowlists, frame/object/base policy
+- `main/src/utils/analytics.js`, `main/src/hooks/usePageTracking.jsx`, or analytics tests: GA4 event shape and page tracking
+- `.github/*`, scripts, or package files: automation, release gates, dependency or command behavior
+
+Output: affected surfaces, likely regressions, required adjacent skills, and minimal command plan.
+
+## Lane 2: Local Release Gate
+
+Goal: prove the repo still builds and core tests pass.
+
+Run only what the risk justifies:
+
+- `git diff --check`
+- `npm run lint`
+- `npm run test`
+- `npm run build`
+- `node .codex/skills/portfolio-performance-auditor/scripts/check_frontend_performance.mjs /Users/waffyahmed/Downloads/personalWebsite`
+- `bash .codex/skills/portfolio-release-qa/scripts/portfolio_preflight.sh /Users/waffyahmed/Downloads/personalWebsite`
+
+Use the performance checker when route loading, image priority, asset delivery, or bundle behavior changed. Use the preflight script for release or push readiness. Use the individual commands when a narrower check gives faster feedback.
+
+## Lane 3: Route And Functionality Smoke
+
+Goal: check user-visible routes and primary actions.
+
+Core routes:
+
+- `/`
+- `/resume`
+- `/projects`
+- `/case-studies`
+- `/experience`
+- `/contact`
+- case-study detail routes from the route/data source
+- `/waffyAhmedResume.pdf`
+- `/llms.txt`
+- `/ai-summary.txt`
+- `/portfolio.json`
+- `/sitemap.xml`
+- `/robots.txt`
+- `/manifest.json`
+
+Regression probes:
+
+- Legacy uppercase routes redirect or render as intended.
+- Canonical lowercase app routes remain the source of truth.
+- Missing routes return a real 404 and crawler `noindex, nofollow` where expected.
+- Resume download/open behavior still reaches `main/public/waffyAhmedResume.pdf`.
+- Contact form UI still renders, validates, and submits only when intentionally tested.
+
+## Lane 4: SEO And Crawler Surface
+
+Goal: verify what crawlers and link previews see before React hydration.
+
+Check:
+
+- Initial HTML title, description, canonical URL, Open Graph, and Twitter metadata for affected routes.
+- Prerender shell output in `dist` after build when route metadata changed.
+- `_redirects`, Netlify redirects, and route casing behavior.
+- `sitemap.xml` and `robots.txt` for canonical route alignment.
+- `.html` aliases and trailing-slash behavior if route metadata or redirects changed.
+- 404 page status and body. Use non-failing curl forms so the body can be inspected.
+
+Prefer expected route metadata from `main/src/data/seo.js` instead of hard-coded assumptions.
+
+## Lane 5: Content, AI Discovery, And Resume Consistency
+
+Goal: keep public machine-readable files aligned with the canonical app data.
+
+Check:
+
+- Visible app content against `main/src/data/*`.
+- `main/public/portfolio.json`.
+- `main/public/ai-summary.txt`.
+- `main/public/llms.txt`.
+- Structured project/case-study metadata.
+- Resume PDF path and preview image.
+- Public content remains focused on Waffy's engineering work rather than website implementation details.
+
+Use the content, AI discovery, and resume skill checkers when these surfaces changed.
+
+## Lane 6: Analytics, CSP, And Security Headers
+
+Goal: catch telemetry, form, and header regressions.
+
+Check:
+
+- GA4 event names are lowercase underscore names.
+- Event params are useful and never empty.
+- Page tracking still follows route transitions.
+- Recommended key-event candidates remain intact: `resume_download`, `contact_form_success`, `project_source_click`, `case_study_link_click`.
+- `netlify.toml` still allows only required scripts, connections, forms, images, frames, and inline JSON-LD hash.
+- If `main/index.html` JSON-LD changed, recompute and verify the CSP `script-src` SHA-256 hash.
+
+Use live browser QA for analytics only when needed; disclose that it may create GA4 page views/users.
+
+## Lane 7: Visual And Browser QA
+
+Goal: catch layout, runtime, and interaction regressions that static checks miss.
+
+Check at desktop and mobile widths:
+
+- Navigation, active route state, and route transitions.
+- Hero and section text for overflow or overlap.
+- Project cards, case-study links, resume actions, social/contact links.
+- Contact form states.
+- Console errors and failed network requests.
+- Any changed visual component on at least one narrow mobile width around 390px.
+
+Clean up transient browser artifacts when they are not part of the requested output.
+
+## Lane 8: Deployed Or Preview Verification
+
+Goal: prove the actual hosted target behaves as claimed.
+
+Use production `https://waffy.dev/`, the Netlify deploy preview URL, or both depending on the request.
+
+Check:
+
+- Final status codes and redirect chains for affected routes.
+- Initial HTML metadata on final `200` route responses.
+- Public static assets return expected statuses and content types.
+- Missing page returns expected 404 behavior and body metadata.
+- Production-specific caveats are classified by practical severity.
+
+Use real HTTP evidence for deployed claims. If sandbox/network limits prevent live checks, say exactly what could not be verified.
+
+## Subagent Prompt Template
+
+Use a narrow, read-only prompt like this:
+
+```text
+Use $adversarial-change-verifier in /Users/waffyahmed/Downloads/personalWebsite for one independent QA lane: <lane name>. Treat this as read-only. Inspect the relevant files or target URLs, run only the checks needed for this lane, and report findings first with exact evidence, commands, confidence, and residual risk. Do not modify files.
+```
+
+For live QA lanes, add:
+
+```text
+If you use a real browser against https://waffy.dev/ or a deploy preview, explicitly note that the visit may contribute to GA4. Prefer curl or Node HTTP checks when browser interactivity is not required.
+```

--- a/.codex/skills/portfolio-audit-maintainer/SKILL.md
+++ b/.codex/skills/portfolio-audit-maintainer/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: portfolio-audit-maintainer
+description: Repository audit maintenance for Waffy Ahmed's personalWebsite. Use when Codex updates, reconciles, or reviews docs/personal-website-repository-audit.md, documents deployed validation findings, reclassifies audit caveats versus real issues, preserves provenance such as creation dates and PR numbers, or aligns audit findings with current production, preview, route, SEO, security, analytics, performance, or content evidence.
+---
+
+# Portfolio Audit Maintainer
+
+## Workflow
+
+1. Check `git status --short` before editing the audit.
+2. Identify the evidence type:
+   - Source audit evidence from the repo.
+   - Local build/test evidence.
+   - Deploy-preview or production HTTP evidence.
+   - Browser QA evidence, including possible GA4 side effects.
+   - Follow-up PRs, issues, or releases that resolved older findings.
+3. Read [references/audit-map.md](references/audit-map.md) before changing `docs/personal-website-repository-audit.md`.
+4. Preserve exact provenance. Keep supplied dates, PR numbers, issue numbers, commit hashes, URLs, and validation dates exact.
+5. Reconcile before appending:
+   - Mark resolved items as resolved when current evidence supports it.
+   - Keep historical findings if they explain the audit trail, but do not present fixed production issues as current.
+   - Separate true breakage from low-severity caveats or nitpicks.
+6. Use adjacent skills for specialized evidence:
+   - `$seo-spa-auditor` for route metadata, redirects, sitemap, robots, and crawler-visible HTML.
+   - `$ai-discovery-maintainer` and `$portfolio-content-sync` for public AI/content surfaces.
+   - `$resume-site-sync` for resume PDF and preview evidence.
+   - `$csp-security-header-maintainer` for CSP and security headers.
+   - `$ga4-portfolio-analytics` when analytics behavior or browser-QA traffic is discussed.
+   - `$portfolio-performance-auditor` for image loading, route lazy loading, or layout/performance follow-ups.
+7. Validate Markdown edits with `git diff --check`. Run broader repo checks only when code, generated artifacts, public content, routes, CSP, analytics, or build behavior changed.
+
+## Reporting
+
+Summarize what audit sections changed, what evidence supports the change, and what was intentionally left historical. Mention browser QA GA4 side effects when relevant.

--- a/.codex/skills/portfolio-audit-maintainer/agents/openai.yaml
+++ b/.codex/skills/portfolio-audit-maintainer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Portfolio Audit Maintainer"
+  short_description: "Keep the repository audit current"
+  default_prompt: "Use $portfolio-audit-maintainer to reconcile my portfolio audit document with current evidence."

--- a/.codex/skills/portfolio-audit-maintainer/references/audit-map.md
+++ b/.codex/skills/portfolio-audit-maintainer/references/audit-map.md
@@ -1,0 +1,52 @@
+# Audit Map
+
+Use this reference when maintaining `docs/personal-website-repository-audit.md`.
+
+## Audit Structure
+
+- Header metadata:
+  - Repository name.
+  - Baseline commit or branch.
+  - Reconciled PRs or comparison point.
+  - Website creation date. Preserve exact supplied provenance such as `Sep 12, 2024 at 2:17 PM`.
+  - Audit scope.
+- Overall assessment:
+  - Keep high-level health and highest-value follow-up themes current.
+  - Avoid overstating resolved issues.
+- Post-deploy validation addendum:
+  - Use only real deploy-preview or production evidence.
+  - Include validation date, target URL, relevant PRs, status-code behavior, route/browser behavior, public assets, and security headers.
+- Resolved sections:
+  - Move or mark findings resolved when follow-up PRs and validation prove the issue is fixed.
+  - Preserve why the item mattered originally.
+- Findings and follow-up work:
+  - Keep unresolved findings actionable, scoped, and supported by current evidence.
+
+## Evidence Standards
+
+- Production or deploy-preview claims need authoritative live evidence from the final URL, not local assumptions.
+- For 404 checks, avoid `curl -f` so the body remains inspectable for `noindex, nofollow`.
+- For crawler-visible metadata, inspect initial HTML and generated prerender shells, not only browser-updated document state.
+- Derive expected route metadata from `main/src/data/seo.js` where possible.
+- Browser QA against `waffy.dev` can create GA4 page views/users. `curl`, Node HTTP checks, Dependabot, CodeQL, and `npm audit` do not run the site in a browser and should not affect GA4.
+- If sandbox/network limits block live evidence, say exactly which claims remain unverified.
+
+## Classification Guidance
+
+- Treat build failures, broken canonical routes, missing public assets, incorrect 404 status, blocked required analytics/form connections, and crawler-visible metadata regressions as real issues.
+- Treat trailing-slash canonical differences, legacy lowercase resume PDF canonicalization, minor mobile nav scrolling, and noisy but non-blocking console output as lower severity unless fresh evidence shows user impact.
+- Do not treat pre-PR129 deep-route homepage metadata findings as current without fresh validation; keep them as historical context if the audit trail needs them.
+
+## Edit Checklist
+
+1. Search the audit for duplicate or stale versions of the finding.
+2. Update the section that owns the current truth instead of appending a contradictory note.
+3. Preserve exact dates, PR numbers, issue numbers, URLs, and commands.
+4. Keep recommendations tied to concrete files or deployed routes.
+5. Run:
+
+```bash
+git diff --check
+```
+
+Run route/content/security/performance skills when those surfaces changed, and record skipped checks in the final response.

--- a/.codex/skills/portfolio-github-automation-maintainer/SKILL.md
+++ b/.codex/skills/portfolio-github-automation-maintainer/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: portfolio-github-automation-maintainer
+description: GitHub automation maintenance for Waffy Ahmed's personalWebsite. Use when Codex changes or reviews GitHub Actions workflows, Dependabot configuration, CodeQL or security scanning setup, npm audit automation, Netlify token rotation reminders, deployed-header checks, release-on-deploy automation, auto-assignment, workflow run failures, or GitHub-managed security-feature overlap.
+---
+
+# Portfolio GitHub Automation Maintainer
+
+## Workflow
+
+1. Check `git status --short` before editing and treat unrelated app changes as user-owned.
+2. Identify the automation surface:
+   - `.github/workflows/dev-ci.yml`: PR lint/test/build gate.
+   - `.github/workflows/release-on-deploy.yml`: production deploy wait and GitHub release creation.
+   - `.github/workflows/npm-audit.yml`: dependency vulnerability audit.
+   - `.github/workflows/deployed-security-headers.yml`: live `waffy.dev` header drift check.
+   - `.github/workflows/netlify-token-rotation-reminder.yml`: token-expiry issue automation.
+   - `.github/workflows/auto-assign-prs.yml`: `pull_request_target` assignment.
+   - `.github/dependabot.yml`: npm and GitHub Actions update grouping.
+   - `.github/workflows/codeql.yml`: checked-in CodeQL analysis, if enabled.
+3. Read [references/github-automation-map.md](references/github-automation-map.md) before changing workflow behavior, permissions, schedules, secrets, repository variables, or security automation.
+4. Prefer repo-owned automation only when it adds value beyond GitHub-managed features. Check existing secret scanning, push protection, Dependabot alerts, Dependabot security updates, and CodeQL/code scanning before adding duplicates.
+5. Keep permissions minimal, avoid secret exposure, and keep `pull_request_target` jobs free of untrusted checkout or script execution.
+6. Run narrow verification first:
+   - YAML/static review for docs-only or metadata-only workflow edits.
+   - `npm run lint`, `npm run test`, and `npm run build` when workflow changes mirror app CI.
+   - `npm audit --audit-level=moderate` only when dependency/audit behavior is in scope.
+   - `gh run view <run_id> --log` when diagnosing a specific Actions run and authenticated `gh` is available.
+7. For publish or release readiness, hand off to `$portfolio-release-qa` or `$git-pr-publisher` as appropriate.
+
+## Reporting
+
+Explain whether failures are real regressions, expected known advisory noise, base-branch workflow artifacts, manual-dispatch override behavior, or GitHub settings gaps. Include exact workflow names, run IDs, issue/PR numbers, and commands used when available.

--- a/.codex/skills/portfolio-github-automation-maintainer/agents/openai.yaml
+++ b/.codex/skills/portfolio-github-automation-maintainer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Portfolio GitHub Automation"
+  short_description: "Maintain portfolio GitHub automation"
+  default_prompt: "Use $portfolio-github-automation-maintainer to update my portfolio GitHub workflows safely."

--- a/.codex/skills/portfolio-github-automation-maintainer/references/github-automation-map.md
+++ b/.codex/skills/portfolio-github-automation-maintainer/references/github-automation-map.md
@@ -1,0 +1,62 @@
+# GitHub Automation Map
+
+Use this reference for workflow, Dependabot, security automation, and GitHub run-diagnosis tasks in this repo.
+
+## Current Automation
+
+| Surface | File | Purpose | Key Notes |
+| --- | --- | --- | --- |
+| Main PR CI | `.github/workflows/dev-ci.yml` | Runs install, lint, tests, and build for PRs to `main`. | Uses Node `22.13.0`, `npm ci`, and `main/package-lock.json` cache path. |
+| Deploy release | `.github/workflows/release-on-deploy.yml` | Verifies app, waits for Netlify production deploy for the pushed commit, then creates a GitHub release. | Requires `NETLIFY_AUTH_TOKEN` and `NETLIFY_SITE_ID`; validates production homepage metadata and legacy resume redirect. |
+| npm audit | `.github/workflows/npm-audit.yml` | Runs `npm audit --audit-level=moderate` on dependency PRs, weekly, and manually. | A failure can be expected if known advisories are still unresolved; do not churn lockfiles unless dependency refresh is in scope. |
+| Deployed headers | `.github/workflows/deployed-security-headers.yml` | Checks production security headers on `https://waffy.dev/`. | Preserve both the independent policy allowlist and the exact comparison with `netlify.toml`. |
+| Netlify token reminder | `.github/workflows/netlify-token-rotation-reminder.yml` | Opens or updates one issue when the Netlify auth token approaches expiration. | `NETLIFY_AUTH_TOKEN_EXPIRES_AT` repository variable is the source of truth; `workflow_dispatch.expiration_date` intentionally overrides it for testing. |
+| Auto assign PRs | `.github/workflows/auto-assign-prs.yml` | Assigns PRs to `waffy1901`. | Runs on `pull_request_target`; do not execute untrusted branch code here. |
+| CodeQL | `.github/workflows/codeql.yml` | Runs JavaScript/TypeScript CodeQL analysis if checked in. | Check GitHub-managed code scanning/default setup before adding or changing duplicate CodeQL automation. |
+| Dependabot | `.github/dependabot.yml` | Groups npm and GitHub Actions dependency updates. | Keep schedules timezone-aware and PR limits modest. |
+
+## Safety Rules
+
+- Use least-privilege `permissions` per workflow and job.
+- Keep `actions/checkout` `persist-credentials: false` unless a job must push.
+- Never print secrets, token values, or full authorization headers.
+- Treat repository variables as non-secret metadata; treat repository secrets as opaque.
+- For `pull_request_target`, avoid checking out or running code from the PR head unless there is a strong, reviewed reason.
+- For Netlify automation, keep `NETLIFY_SITE_ID` and `NETLIFY_AUTH_TOKEN` distinct, and do not store token values in docs, issues, commits, or logs.
+
+## Diagnosis Patterns
+
+- Specific workflow run:
+
+```bash
+gh run view <run_id> --log
+```
+
+- Specific issue created by automation:
+
+```bash
+gh issue view <issue_number>
+```
+
+- Manual Netlify reminder tests:
+  - `workflow_dispatch.expiration_date` overrides the repository variable.
+  - `force_issue: true` is the clean way to test issue creation without pretending the real token expires early.
+  - The workflow uses a marker comment so it updates one reminder issue instead of creating duplicates.
+
+- `pull_request_target` failures:
+  - The workflow definition comes from the base branch, usually `main`.
+  - A PR can contain a fix while the check still uses stale base-branch YAML until merged.
+
+## Verification Guidance
+
+- For `.github/workflows/dev-ci.yml` or release verification changes, run the same root scripts locally when practical:
+
+```bash
+npm run lint
+npm run test
+npm run build
+```
+
+- For deployed header automation, keep `scripts/check-deployed-security-headers.py` aligned with intentional policy changes. Do not remove its independent minimum requirements merely because `netlify.toml` and production match.
+- For dependency automation, separate updater config changes from dependency refresh PRs unless the user asks for both.
+- For security feature requests, verify whether GitHub-managed secret scanning, push protection, Dependabot alerts, Dependabot security updates, and CodeQL/code scanning are already enabled before adding workflows.

--- a/.codex/skills/portfolio-performance-auditor/SKILL.md
+++ b/.codex/skills/portfolio-performance-auditor/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: portfolio-performance-auditor
+description: Frontend performance auditing for Waffy Ahmed's personalWebsite React/Vite portfolio. Use when Codex changes route-level code splitting, image loading priority, asset delivery, page weight, layout responsiveness, Vite build output, lazy/eager loading behavior, or wants to check performance regressions without turning the task into a full release QA pass.
+---
+
+# Portfolio Performance Auditor
+
+## Workflow
+
+1. Check `git status --short` and identify unrelated user changes before editing.
+2. Map the changed files to performance surfaces:
+   - `main/src/App.jsx`: route-level lazy loading, `Suspense`, fallback accessibility, route chunk boundaries.
+   - `main/src/pages/*` and `main/src/components/*`: image priority, rendered DOM size, expensive repeated work, mobile layout stability.
+   - `main/src/images/*` and `main/public/*`: image dimensions, formats, static asset delivery, resume preview and Open Graph assets.
+   - `main/src/index.css` and Tailwind classes: overflow, hidden content, layout shift, responsive constraints.
+   - `main/package.json`, Vite config, or scripts: build output, dependencies, and production bundling behavior.
+3. Run the focused static check when route lazy loading or image markup is in scope:
+
+```bash
+node .codex/skills/portfolio-performance-auditor/scripts/check_frontend_performance.mjs /path/to/personalWebsite
+```
+
+When changing the checker itself, run its regression test:
+
+```bash
+node --test .codex/skills/portfolio-performance-auditor/scripts/test_frontend_performance.mjs
+```
+
+4. Run tests that cover the changed behavior. For route lazy loading or image policy, `main/src/App.test.jsx` should assert the behavior directly.
+5. For user-visible performance work, build and inspect production output:
+
+```bash
+npm run build
+```
+
+6. When layout or runtime performance is in scope, run a preview/dev server and inspect affected routes at desktop and a narrow mobile width. Browser QA against `waffy.dev` can count as GA4 traffic; local browser checks, `curl`, Node scripts, and builds do not affect GA4.
+
+Read [references/performance-map.md](references/performance-map.md) for route, image, layout, and verification guidance.
+
+## Reporting
+
+Lead with regressions or missing evidence. Separate true performance breakage from lower-risk tuning opportunities, and list commands run plus checks skipped.

--- a/.codex/skills/portfolio-performance-auditor/agents/openai.yaml
+++ b/.codex/skills/portfolio-performance-auditor/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Portfolio Performance Auditor"
+  short_description: "Audit route and asset performance"
+  default_prompt: "Use $portfolio-performance-auditor to check my portfolio for performance regressions."

--- a/.codex/skills/portfolio-performance-auditor/references/performance-map.md
+++ b/.codex/skills/portfolio-performance-auditor/references/performance-map.md
@@ -1,0 +1,54 @@
+# Performance Map
+
+Use this reference when performance, image behavior, lazy loading, or responsive rendering is the main risk.
+
+## Route Loading
+
+- Keep the default Home route eager so its hero image is discovered without an extra route-chunk request. Split secondary and catch-all routes with `React.lazy` and wrap them in `Suspense`.
+- Keep the route fallback accessible with `role="status"` and `aria-live="polite"` so loading state is announced without becoming noisy.
+- Check legacy uppercase redirects whenever changing route definitions; route performance changes should not break canonical routing.
+- Keep route-level tests async when lazy-loaded pages render through `Suspense`.
+
+## Image Policy
+
+- Above-the-fold LCP candidates should be explicit:
+  - Home profile image: `loading="eager"`, `fetchPriority="high"`, `decoding="async"`.
+  - Resume preview image: `loading="eager"`, `fetchPriority="high"`, `decoding="async"`.
+- Repeated logos, project thumbnails, case-study images, and below-the-fold assets should use `loading="lazy"` and `decoding="async"`.
+- Avoid adding remote image hosts without checking `netlify.toml` CSP image and connect allowlists.
+- Prefer generated or existing bitmap assets for inspectable images; do not replace real portfolio imagery with decorative CSS/SVG placeholders.
+
+## Layout And Runtime Checks
+
+- Inspect changed routes at desktop width and around 390px mobile width when visual layout changed.
+- Check for text overflow, clipped buttons, overlapping cards, horizontal scroll, and route fallback layout shift.
+- Watch browser console output for failed chunks, missing assets, hydration/runtime errors, or blocked CSP requests.
+- If testing production with a real browser, disclose possible GA4 traffic. Prefer local preview or non-browser HTTP checks when analytics side effects are not needed.
+
+## Verification Menu
+
+- Static policy check:
+
+```bash
+node .codex/skills/portfolio-performance-auditor/scripts/check_frontend_performance.mjs /Users/waffyahmed/Downloads/personalWebsite
+```
+
+- Checker regression test:
+
+```bash
+node --test .codex/skills/portfolio-performance-auditor/scripts/test_frontend_performance.mjs
+```
+
+- Focused tests:
+
+```bash
+npm run test
+```
+
+- Production build and bundle sanity:
+
+```bash
+npm run build
+```
+
+- Release-grade verification should hand off to `$portfolio-release-qa` after the focused performance checks pass.

--- a/.codex/skills/portfolio-performance-auditor/scripts/check_frontend_performance.mjs
+++ b/.codex/skills/portfolio-performance-auditor/scripts/check_frontend_performance.mjs
@@ -1,0 +1,261 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync, readdirSync } from "node:fs"
+import { join, relative } from "node:path"
+
+const repoRoot = process.argv[2] || process.cwd()
+const srcRoot = join(repoRoot, "main", "src")
+const errors = []
+const warnings = []
+const lcpImagePolicies = [
+  {
+    file: join(srcRoot, "pages", "Home.jsx"),
+    label: "Home profile image",
+    pattern: /src=\{profile\.profilePicture\}/,
+  },
+  {
+    file: join(srcRoot, "pages", "Resume.jsx"),
+    label: "Resume preview image",
+    pattern: /resume-preview\.png|resumePreview|src=\{resume\.preview\}/,
+  },
+]
+
+function readText(filePath) {
+  try {
+    return readFileSync(filePath, "utf8")
+  } catch (error) {
+    errors.push(`Unable to read ${relative(repoRoot, filePath)}: ${error.message}`)
+    return ""
+  }
+}
+
+function walkJsxFiles(dir) {
+  if (!existsSync(dir)) {
+    errors.push(`Missing source directory: ${relative(repoRoot, dir)}`)
+    return []
+  }
+
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const fullPath = join(dir, entry.name)
+
+    if (entry.isDirectory()) {
+      return walkJsxFiles(fullPath)
+    }
+
+    return entry.isFile() && fullPath.endsWith(".jsx") ? [fullPath] : []
+  })
+}
+
+function stripJsxComments(source) {
+  return source.replace(/\{\s*\/\*[\s\S]*?\*\/\s*\}/g, "")
+}
+
+function imgTags(source) {
+  return [...stripJsxComments(source).matchAll(/<img\b[\s\S]*?(?:\/>|>)/g)].map(
+    (match) => match[0],
+  )
+}
+
+function attrValue(tag, attrName) {
+  const escaped = attrName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+  const match = new RegExp(`(?:^|\\s)${escaped}\\s*=\\s*(?:"([^"]*)"|'([^']*)'|\\{([^}]*)\\})`, "i").exec(tag)
+  return match ? match[1] ?? match[2] ?? match[3] ?? "" : null
+}
+
+function normalizedAttrValue(value) {
+  return value?.replace(/["'{}]/g, "").trim().toLowerCase() ?? null
+}
+
+function shortTag(tag) {
+  return tag.replace(/\s+/g, " ").slice(0, 140)
+}
+
+function jsxTagEnd(source, tagStart) {
+  let braceDepth = 0
+  let quote = null
+
+  for (let index = tagStart; index < source.length; index += 1) {
+    const character = source[index]
+
+    if (quote) {
+      if (character === quote && source[index - 1] !== "\\") {
+        quote = null
+      }
+      continue
+    }
+
+    if (character === '"' || character === "'") {
+      quote = character
+    } else if (character === "{") {
+      braceDepth += 1
+    } else if (character === "}") {
+      braceDepth = Math.max(0, braceDepth - 1)
+    } else if (character === ">" && braceDepth === 0) {
+      return index
+    }
+  }
+
+  return -1
+}
+
+function hasSuspenseWrappedRoutes(source) {
+  const sourceWithoutComments = stripJsxComments(source)
+  const routesStart = sourceWithoutComments.search(/<Routes\b/)
+  const routesEnd = sourceWithoutComments.indexOf("</Routes>", routesStart)
+
+  if (routesStart === -1 || routesEnd === -1) {
+    return false
+  }
+
+  const openBoundaries = []
+  const pairedBoundaries = []
+
+  for (const match of sourceWithoutComments.matchAll(/<(\/)?(?:React\.)?Suspense\b/g)) {
+    if (match[1]) {
+      const start = openBoundaries.pop()
+      if (start !== undefined) {
+        pairedBoundaries.push({ start, end: match.index })
+      }
+      continue
+    }
+
+    const tagEnd = jsxTagEnd(sourceWithoutComments, match.index)
+    const openingTag = sourceWithoutComments.slice(match.index, tagEnd + 1)
+    if (tagEnd !== -1 && !/\/\s*>$/.test(openingTag)) {
+      openBoundaries.push(match.index)
+    }
+  }
+
+  return pairedBoundaries.some(
+    ({ start, end }) => start < routesStart && end > routesEnd,
+  )
+}
+
+function checkAppLazyLoading() {
+  const appPath = join(srcRoot, "App.jsx")
+  const appSource = readText(appPath)
+  const eagerHomePattern = /import\s+Home\s+from\s+["']\.\/pages\/Home\.jsx["']/
+  const lazyRoutePolicies = [
+    { page: "Resume", path: "/resume" },
+    { page: "Contact", path: "/contact" },
+    { page: "CaseStudies", path: "/case-studies" },
+    { page: "CaseStudy", path: "/case-studies/:slug" },
+    { page: "Experience", path: "/experience" },
+    { page: "Projects", path: "/projects" },
+    { page: "NotFound", path: "*" },
+  ]
+
+  if (!eagerHomePattern.test(appSource)) {
+    errors.push("main/src/App.jsx should import Home eagerly for the default route.")
+  }
+
+  if (/\bconst\s+Home\s*=\s*lazy\s*\(/.test(appSource)) {
+    errors.push("main/src/App.jsx should not lazy-load Home because it delays homepage LCP discovery.")
+  }
+
+  for (const { page, path } of lazyRoutePolicies) {
+    const escapedPage = page.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+    const escapedPath = path.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+    const lazyImportPattern = new RegExp(
+      `\\bconst\\s+${escapedPage}\\s*=\\s*lazy\\s*\\(\\s*\\(\\)\\s*=>\\s*import\\(\\s*["']\\.\\/pages\\/${escapedPage}\\.jsx["']\\s*\\)\\s*\\)`,
+    )
+    const routePattern = new RegExp(
+      `<Route\\b(?:(?!<Route\\b)[\\s\\S])*?\\bpath\\s*=\\s*["']${escapedPath}["'](?:(?!<Route\\b)[\\s\\S])*?\\belement\\s*=\\s*\\{\\s*<${escapedPage}\\s*\\/>\\s*\\}`,
+    )
+
+    if (!lazyImportPattern.test(appSource)) {
+      errors.push(`main/src/App.jsx should lazy-load ${page} from ./pages/${page}.jsx.`)
+    }
+
+    if (!routePattern.test(appSource)) {
+      errors.push(`main/src/App.jsx should render ${page} for route ${path}.`)
+    }
+  }
+
+  if (!hasSuspenseWrappedRoutes(appSource)) {
+    errors.push("main/src/App.jsx should wrap lazy routes in Suspense.")
+  }
+
+  if (!/RouteLoadingFallback/.test(appSource)) {
+    warnings.push("main/src/App.jsx does not define RouteLoadingFallback; confirm the Suspense fallback is accessible.")
+  }
+
+  if (!/role=\"status\"/.test(appSource) || !/aria-live=\"polite\"/.test(appSource)) {
+    warnings.push("Route loading fallback should expose role=\"status\" and aria-live=\"polite\".")
+  }
+}
+
+function checkImageTags() {
+  for (const filePath of walkJsxFiles(srcRoot)) {
+    const relativePath = relative(repoRoot, filePath)
+    const source = readText(filePath)
+
+    for (const tag of imgTags(source)) {
+      const loading = attrValue(tag, "loading")
+      const decoding = attrValue(tag, "decoding")
+      const fetchPriority = attrValue(tag, "fetchPriority") ?? attrValue(tag, "fetchpriority")
+      const isLcpImage = lcpImagePolicies.some(
+        (image) => image.file === filePath && image.pattern.test(tag),
+      )
+
+      if (normalizedAttrValue(decoding) !== "async") {
+        errors.push(`${relativePath} has an <img> without decoding="async": ${shortTag(tag)}`)
+      }
+
+      if (!isLcpImage && loading !== "lazy") {
+        errors.push(`${relativePath} has a non-LCP <img> without loading=\"lazy\": ${shortTag(tag)}`)
+      }
+
+      if (!isLcpImage && normalizedAttrValue(fetchPriority) === "high") {
+        errors.push(`${relativePath} has fetchPriority=\"high\" on a non-LCP <img>: ${shortTag(tag)}`)
+      }
+
+      if (/\{\s*\.\.\./.test(tag)) {
+        warnings.push(`${relativePath} uses spread props on an <img>; inspect image policy manually: ${shortTag(tag)}`)
+      }
+    }
+  }
+}
+
+function checkHeroImagePolicy() {
+  for (const image of lcpImagePolicies) {
+    const source = readText(image.file)
+    const tags = imgTags(source)
+    const tag = tags.find((candidate) => image.pattern.test(candidate))
+    const relativePath = relative(repoRoot, image.file)
+
+    if (!tag) {
+      warnings.push(`${image.label} was not found in ${relativePath}; confirm LCP image policy manually.`)
+      continue
+    }
+
+    if (attrValue(tag, "loading") !== "eager") {
+      errors.push(`${image.label} should use loading=\"eager\" in ${relativePath}.`)
+    }
+
+    const fetchPriority = attrValue(tag, "fetchPriority") ?? attrValue(tag, "fetchpriority")
+    if (fetchPriority !== "high") {
+      errors.push(`${image.label} should use fetchPriority=\"high\" in ${relativePath}.`)
+    }
+
+    if (normalizedAttrValue(attrValue(tag, "decoding")) !== "async") {
+      errors.push(`${image.label} should use decoding=\"async\" in ${relativePath}.`)
+    }
+  }
+}
+
+checkAppLazyLoading()
+checkImageTags()
+checkHeroImagePolicy()
+
+for (const warning of warnings) {
+  console.warn(`[warn] ${warning}`)
+}
+
+if (errors.length > 0) {
+  for (const error of errors) {
+    console.error(`[error] ${error}`)
+  }
+  process.exit(1)
+}
+
+console.log("Frontend performance policy check passed.")

--- a/.codex/skills/portfolio-performance-auditor/scripts/test_frontend_performance.mjs
+++ b/.codex/skills/portfolio-performance-auditor/scripts/test_frontend_performance.mjs
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict"
+import { spawnSync } from "node:child_process"
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+import test from "node:test"
+import { fileURLToPath } from "node:url"
+
+const checkerPath = join(dirname(fileURLToPath(import.meta.url)), "check_frontend_performance.mjs")
+
+function writeFixture(root, relativePath, contents) {
+  const filePath = join(root, relativePath)
+  mkdirSync(dirname(filePath), { recursive: true })
+  writeFileSync(filePath, contents)
+}
+
+function replaceFixture(root, relativePath, replacements) {
+  const filePath = join(root, relativePath)
+  let contents = readFileSync(filePath, "utf8")
+
+  for (const [from, to] of replacements) {
+    assert.ok(contents.includes(from), `Fixture is missing expected text: ${from}`)
+    contents = contents.replace(from, to)
+  }
+
+  writeFileSync(filePath, contents)
+}
+
+function runChecker(fixtureRoot) {
+  return spawnSync(process.execPath, [checkerPath, fixtureRoot], { encoding: "utf8" })
+}
+
+function createFixture(decoding) {
+  const root = mkdtempSync(join(tmpdir(), "portfolio-performance-"))
+
+  writeFixture(
+    root,
+    "main/src/App.jsx",
+    [
+      'import { lazy, Suspense } from "react"',
+      'import { Route, Routes } from "react-router-dom"',
+      'import Home from "./pages/Home.jsx"',
+      "",
+      'const Resume = lazy(() => import("./pages/Resume.jsx"))',
+      'const Contact = lazy(() => import("./pages/Contact.jsx"))',
+      'const CaseStudies = lazy(() => import("./pages/CaseStudies.jsx"))',
+      'const CaseStudy = lazy(() => import("./pages/CaseStudy.jsx"))',
+      'const Experience = lazy(() => import("./pages/Experience.jsx"))',
+      'const Projects = lazy(() => import("./pages/Projects.jsx"))',
+      'const NotFound = lazy(() => import("./pages/NotFound.jsx"))',
+      "",
+      "function RouteLoadingFallback() {",
+      '  return <div role="status" aria-live="polite">Loading</div>',
+      "}",
+      "",
+      "export default function App() {",
+      "  return (",
+      "    <Suspense fallback={<RouteLoadingFallback />}>",
+      "      <Routes>",
+      '        <Route path="/" element={<Home />} />',
+      '        <Route path="/resume" element={<Resume />} />',
+      '        <Route path="/contact" element={<Contact />} />',
+      '        <Route path="/case-studies" element={<CaseStudies />} />',
+      '        <Route path="/case-studies/:slug" element={<CaseStudy />} />',
+      '        <Route path="/experience" element={<Experience />} />',
+      '        <Route path="/projects" element={<Projects />} />',
+      '        <Route path="*" element={<NotFound />} />',
+      "      </Routes>",
+      "    </Suspense>",
+      "  )",
+      "}",
+      "",
+    ].join("\n"),
+  )
+  writeFixture(
+    root,
+    "main/src/pages/Home.jsx",
+    [
+      "export default function Home({ profile }) {",
+      '  return <img src={profile.profilePicture} loading="eager" fetchPriority="high" decoding="async" alt="Profile" />',
+      "}",
+      "",
+    ].join("\n"),
+  )
+  writeFixture(
+    root,
+    "main/src/pages/Resume.jsx",
+    [
+      "export default function Resume() {",
+      '  return <img src="/resume-preview.png" loading="eager" fetchPriority="high" decoding="async" alt="Resume preview" />',
+      "}",
+      "",
+    ].join("\n"),
+  )
+  writeFixture(
+    root,
+    "main/src/components/ProjectCard.jsx",
+    [
+      "export default function ProjectCard() {",
+      '  return <img src="/project.png" loading="lazy" decoding="' + decoding + '" alt="Project" />',
+      "}",
+      "",
+    ].join("\n"),
+  )
+
+  return root
+}
+
+test("accepts a valid route and image fixture", () => {
+  const fixtureRoot = createFixture("async")
+
+  try {
+    const result = runChecker(fixtureRoot)
+
+    assert.equal(result.status, 0)
+    assert.match(result.stdout, /policy check passed/)
+    assert.equal(result.stderr, "")
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true })
+  }
+})
+
+test('rejects image decoding values other than "async"', () => {
+  const fixtureRoot = createFixture("sync")
+
+  try {
+    const result = runChecker(fixtureRoot)
+
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /ProjectCard\.jsx has an <img> without decoding="async"/)
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true })
+  }
+})
+
+test("rejects data attributes that resemble image policy attributes", () => {
+  const fixtureRoot = createFixture("async")
+
+  try {
+    replaceFixture(fixtureRoot, "main/src/components/ProjectCard.jsx", [
+      ['loading="lazy"', 'data-loading="lazy"'],
+      ['decoding="async"', 'data-decoding="async"'],
+    ])
+    const result = runChecker(fixtureRoot)
+
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /without decoding="async"/)
+    assert.match(result.stderr, /without loading="lazy"/)
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true })
+  }
+})
+
+test("rejects lazy pages that are not used by their routes", () => {
+  const fixtureRoot = createFixture("async")
+
+  try {
+    replaceFixture(fixtureRoot, "main/src/App.jsx", [
+      ['path="/resume" element={<Resume />}', 'path="/resume" element={<Home />}'],
+    ])
+    const result = runChecker(fixtureRoot)
+
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /should render Resume for route \/resume/)
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true })
+  }
+})
+
+test("rejects an unrelated Suspense boundary outside the route tree", () => {
+  const fixtureRoot = createFixture("async")
+
+  try {
+    replaceFixture(fixtureRoot, "main/src/App.jsx", [
+      [
+        "    <Suspense fallback={<RouteLoadingFallback />}>",
+        "    <>\n      <Suspense fallback={null}><Home /></Suspense>",
+      ],
+      ["    </Suspense>", "    </>"],
+    ])
+    const result = runChecker(fixtureRoot)
+
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /should wrap lazy routes in Suspense/)
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true })
+  }
+})
+
+test("rejects sibling Suspense boundaries around an unwrapped route tree", () => {
+  const fixtureRoot = createFixture("async")
+
+  try {
+    replaceFixture(fixtureRoot, "main/src/App.jsx", [
+      [
+        "    <Suspense fallback={<RouteLoadingFallback />}>",
+        "    <>\n      <Suspense fallback={null}><Home /></Suspense>",
+      ],
+      [
+        "    </Suspense>",
+        "      <Suspense fallback={null}><Home /></Suspense>\n    </>",
+      ],
+    ])
+    const result = runChecker(fixtureRoot)
+
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /should wrap lazy routes in Suspense/)
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true })
+  }
+})

--- a/.github/workflows/deployed-security-headers.yml
+++ b/.github/workflows/deployed-security-headers.yml
@@ -18,88 +18,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Test deployed header checker
+        run: python3 scripts/test_deployed_security_headers.py
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.13.0
+
+      - name: Verify CSP JSON-LD hash
+        run: node .codex/skills/csp-security-header-maintainer/scripts/check_csp_jsonld_hash.mjs "$GITHUB_WORKSPACE"
+
       - name: Check production headers
         env:
           SITE_URL: https://waffy.dev/
-        run: |
-          set -euo pipefail
-
-          headers_file="$(mktemp)"
-          status_code="$(curl --silent --show-error --location --head \
-            --retry 3 --retry-delay 5 --connect-timeout 10 --max-time 30 \
-            --dump-header "$headers_file" --output /dev/null \
-            --write-out "%{http_code}" "$SITE_URL")"
-
-          if [ "$status_code" != "200" ]; then
-            echo "Expected HTTP 200 from ${SITE_URL}, got ${status_code}."
-            cat "$headers_file"
-            exit 1
-          fi
-
-          headers="$(tr -d '\r' < "$headers_file")"
-
-          get_header() {
-            local header_name
-            header_name="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
-            printf '%s\n' "$headers" | awk -v name="$header_name" '
-              BEGIN { FS = ":" }
-              tolower($1) == name {
-                sub(/^[^:]*:[[:space:]]*/, "", $0)
-                print
-                exit
-              }
-            '
-          }
-
-          require_header_value() {
-            local header_name="$1"
-            local expected_value="$2"
-            local actual_value
-            actual_value="$(get_header "$header_name")"
-
-            if [ "$actual_value" != "$expected_value" ]; then
-              echo "Unexpected ${header_name} header."
-              echo "Expected: ${expected_value}"
-              echo "Actual:   ${actual_value:-<missing>}"
-              exit 1
-            fi
-          }
-
-          require_header_fragment() {
-            local header_name="$1"
-            local required_fragment="$2"
-            local actual_value
-            actual_value="$(get_header "$header_name")"
-
-            if [[ "$actual_value" != *"$required_fragment"* ]]; then
-              echo "Missing ${header_name} fragment: ${required_fragment}"
-              echo "Actual: ${actual_value:-<missing>}"
-              exit 1
-            fi
-          }
-
-          require_header_value "x-content-type-options" "nosniff"
-          require_header_value "referrer-policy" "strict-origin-when-cross-origin"
-          require_header_value "strict-transport-security" "max-age=31536000; includeSubDomains"
-
-          for permission in "camera=()" "microphone=()" "geolocation=()" "payment=()" "usb=()"; do
-            require_header_fragment "permissions-policy" "$permission"
-          done
-
-          for directive in \
-            "default-src 'self'" \
-            "base-uri 'self'" \
-            "object-src 'none'" \
-            "frame-ancestors 'none'" \
-            "script-src 'self' 'sha256-o8X4zLmKyHMSpaE9szWdmwLAs2MoAe/uoPsAazCcKQI=' https://www.googletagmanager.com" \
-            "connect-src 'self' https://formspree.io https://www.google-analytics.com https://*.google-analytics.com https://analytics.google.com https://*.analytics.google.com" \
-            "img-src 'self' data: https://www.googletagmanager.com https://www.google-analytics.com https://*.google-analytics.com" \
-            "style-src 'self' 'unsafe-inline'" \
-            "font-src 'self' data:" \
-            "form-action 'self' https://formspree.io" \
-            "frame-src 'none'" \
-            "upgrade-insecure-requests"; do
-            require_header_fragment "content-security-policy" "$directive"
-          done
-
-          echo "Production security headers match expected policy."
+        run: python3 scripts/check-deployed-security-headers.py --repo "$GITHUB_WORKSPACE" --site-url "$SITE_URL"

--- a/docs/personal-website-repository-audit.md
+++ b/docs/personal-website-repository-audit.md
@@ -2,7 +2,8 @@
 
 **Repository:** `waffy1901/personalWebsite`  
 **Baseline reviewed:** `main` at `4f05b954309f7f6117549fee9d9537eab8014367`  
-**Reconciled against:** PR #125 (`overhaul/v2`)  
+**Reconciled through:** PR #131 (`feat/generate-public-artifacts`) at `a3cb39b`, including PR #129 (`prerenderRouteMetadata`)<br>
+**Latest audit pass:** Jul 5, 2026 repo-wide local audit on `main` with current uncommitted performance/image-loading changes present<br>
 **Website creation date:** Sep 12, 2024 at 2:17 PM<br>
 **Audit scope:** React application, content and data modules, tests, dependencies, Netlify configuration, public metadata, security controls, and GitHub Actions.
 
@@ -17,11 +18,15 @@
 
 The portfolio is in **good engineering shape**. It presents a distinctive, recruiter-oriented platform and reliability narrative while also demonstrating meaningful engineering discipline through automated testing, dependency scanning, CodeQL, deployment validation, analytics, structured data, and accessible interaction patterns.
 
-No obvious build-breaking or critical security issue was found. The highest-value remaining work is architectural rather than cosmetic:
+No obvious build-breaking or critical security issue was found. The original
+highest-risk architectural gap, crawler-visible route metadata, has since been
+resolved by the prerendered route-shell work. The highest-value remaining work
+is now operational polish and regression protection:
 
-1. Pre-render canonical routes so crawlers and link-preview clients receive route-specific metadata.
-2. Generate public documentation and AI-readable artifacts from canonical data to prevent drift.
-3. Add targeted accessibility, performance, and security hardening.
+1. Release or continue validating the current route lazy-loading and image-loading improvements.
+2. Add targeted accessibility, visual, and performance regression checks.
+3. Add a concise privacy disclosure and review Formspree abuse controls.
+4. Clean up low-severity URL canonicalization and analytics allowlist caveats.
 
 ---
 
@@ -80,6 +85,52 @@ several sub-agents could not resolve `waffy.dev`. The successful production
 evidence above came from the main validation pass with approved live network
 access and Playwright browser checks.
 
+### Jul 5, 2026 Repo-Wide Reconciliation
+
+This pass audited the current repository state, including the existing
+uncommitted route lazy-loading and image-loading changes. It used source
+inspection, local checks, a production build, local preview HTTP checks, and
+read-only production HTTP checks. No browser automation was used in this pass,
+so the Jul 5 checks should not add GA4 page views/users.
+
+Validated local evidence:
+
+- `git diff --check`, `npm run lint`, `npm run test`, `npm run build`, and the
+  release preflight script all passed.
+- `npm audit --audit-level=moderate` reported `0` vulnerabilities.
+- Focused repository checks passed for frontend performance policy, content
+  synchronization, resume assets, SPA SEO, AI discovery, CSP JSON-LD hash, and
+  GA4 event coverage.
+- The production build generated route chunks and prerendered metadata shells
+  for 9 routes. Generated `dist` route shells such as
+  `projects/index.html`, `resume/index.html`, and
+  `case-studies/kubernetes-autoscaling/index.html` contain route-specific
+  title, canonical, robots, and Open Graph metadata.
+- Local Vite preview serves trailing-slash route URLs and direct
+  `index.html` shell URLs with the expected metadata. Vite preview does not
+  apply Netlify `_redirects`, so slashless local preview URLs are not
+  authoritative for Netlify rewrite behavior.
+
+Validated production HTTP evidence from `https://waffy.dev` on Jul 5, 2026:
+
+- `/projects`, `/resume`, and
+  `/case-studies/kubernetes-autoscaling` returned HTTP 301 to trailing-slash
+  URLs.
+- The corresponding trailing-slash pages returned HTTP 200 with route-specific
+  initial HTML metadata and slashless canonical URLs.
+- `/projects.html` and `/missing-page` returned HTTP 404 with
+  `noindex, nofollow`.
+- `/waffyAhmedResume.pdf`, `/llms.txt`, `/ai-summary.txt`,
+  `/portfolio.json`, `/sitemap.xml`, `/robots.txt`, and `/manifest.json`
+  returned HTTP 200.
+- `/waffyahmedresume.pdf` still returned HTTP 200 rather than redirecting to
+  `/waffyAhmedResume.pdf`; this remains a low-severity canonical hygiene item.
+
+The Jun 30 browser-observed GA4 CSP caveat was not re-browser-tested during
+this pass. The current local CSP still does not explicitly allow
+`stats.g.doubleclick.net` or `www.google.com/g/collect`, so the audit keeps that
+item as an analytics follow-up rather than marking it resolved.
+
 ---
 
 ## Resolved in PR #125
@@ -115,27 +166,41 @@ Recent follow-up work addressed several additional findings from this audit:
 - Replaced the soft-404 SPA catch-all with explicit Netlify route rewrites and
   a real static `404.html` response for unknown paths.
 
+## Resolved in PR #129
+
+PR #129 addressed the original deep-route metadata finding by generating
+route-specific HTML shells during the production build and pointing Netlify
+canonical route rewrites at those shells.
+
+Jul 5, 2026 production validation confirmed that route-specific initial HTML
+metadata is present after the current trailing-slash redirect behavior. The
+remaining route caveat is canonicalization polish, not missing metadata.
+
 ---
 
 # Findings and Follow-Up Work
 
-## 1. High: Deep Routes Initially Publish Homepage Metadata
+## 1. Resolved: Canonical Routes Publish Route-Specific Initial Metadata
 
-Netlify currently sends application routes to the same `index.html` file through the SPA rewrite:
+The baseline and Jun 30 deployed audit found that Netlify sent application
+routes to the same homepage-flavored `index.html` shell:
 
 ```text
 /* /index.html 200
 ```
 
-The initial HTML contains homepage-specific title, canonical, and Open Graph values. React replaces them after the application runs, but crawlers, AI fetchers, messaging clients, and social-preview generators that do not execute JavaScript may continue to see homepage metadata for routes such as:
+That meant crawlers, AI fetchers, messaging clients, and social-preview
+generators that do not execute JavaScript could see homepage metadata for deep
+routes such as:
 
 ```text
 /case-studies/kubernetes-autoscaling
 ```
 
-### Recommended Correction
+### Resolution
 
-Pre-render static HTML for every canonical route during the build:
+The current build now prerenders static metadata shells for every canonical
+route:
 
 - `/`
 - `/experience`
@@ -145,7 +210,13 @@ Pre-render static HTML for every canonical route during the build:
 - `/case-studies`
 - Each individual case study
 
-The route-level metadata definitions already exist; the missing step is publishing them in the initial HTML response.
+`npm run build` on Jul 5, 2026 reported `Pre-rendered metadata shells for 9
+routes`, and `check_spa_seo.mjs` passed. Production HTTP checks also confirmed
+that trailing-slash route URLs serve route-specific titles and canonicals.
+
+Keep the remaining trailing-slash behavior tracked as URL canonicalization
+polish: production currently redirects `/projects` to `/projects/`, while the
+served shell canonical remains `https://waffy.dev/projects`.
 
 **Relevant files:**
 
@@ -179,18 +250,24 @@ allows unknown paths to return HTTP 404. Deployed validation confirmed
 
 ---
 
-## 3. High-Medium: Documentation and AI Artifacts Can Drift
+## 3. Addressed: Documentation and AI Artifacts Are Generated
 
 PR #127 corrected the known React-version and hero-description drift in
-`main/README.md` and `main/public/ai-summary.txt`. The broader risk remains:
-public documentation and AI-readable artifacts can still drift because several
-surfaces are maintained manually.
+`main/README.md` and `main/public/ai-summary.txt`. The current repository goes
+further by generating the public documentation and AI-readable artifacts from
+canonical source modules.
 
-The same career claims and metrics also appear across JavaScript data modules, JSON-LD, `portfolio.json`, `ai-summary.txt`, `llms.txt`, the sitemap, and both READMEs. Manual synchronization across these surfaces is likely to drift again.
+`main/scripts/generate-public-artifacts.mjs` now updates `portfolio.json`,
+`ai-summary.txt`, `llms.txt`, `sitemap.xml`, JSON-LD in `main/index.html`, the
+CSP JSON-LD hash in `netlify.toml`, and generated README blocks. The Jul 5,
+2026 build reported `Generated public artifacts are already current`, and the
+content sync plus AI discovery checks passed.
 
-### Recommended Correction
+### Remaining Risk
 
-Treat the data modules as the canonical source and generate public artifacts during the build:
+Wire the generator's check mode and the focused content, AI discovery, CSP, and
+GA4 checks into release/pre-push validation so future content edits cannot drift
+silently. The useful model is already in place:
 
 ```text
 src/data/
@@ -207,8 +284,6 @@ JSON-LD
 sitemap.xml
 ```
 
-Add synchronization tests covering framework versions, case-study slugs, primary metrics, resume links, and social URLs.
-
 **Relevant files:**
 
 - `main/package.json`
@@ -217,6 +292,7 @@ Add synchronization tests covering framework versions, case-study slugs, primary
 - `main/public/ai-summary.txt`
 - `main/public/portfolio.json`
 - `main/public/sitemap.xml`
+- `main/scripts/generate-public-artifacts.mjs`
 - `main/src/data/`
 
 ---
@@ -251,26 +327,40 @@ preserved.
 
 # Architecture and Performance
 
-## 5. Medium: Secondary Routes Are Loaded Eagerly
+## 5. Addressed in Current Working Tree: Secondary Routes Are Lazy-Loaded
 
-`App.jsx` statically imports all route pages. The site is still small, but route-level lazy loading would keep the initial homepage bundle focused as the portfolio grows.
+The baseline audit flagged that `App.jsx` statically imported every route page.
+The current uncommitted working tree now uses `React.lazy`, `Suspense`, and an
+accessible route-loading fallback to split secondary route code.
 
-Keep the homepage eager and lazy-load secondary routes through `React.lazy` and `Suspense`.
+Jul 5, 2026 validation confirmed the related app tests are async-aware, the
+focused frontend performance policy check passed, and the production build emits
+separate route chunks. Keep this item as pending release validation until the
+working-tree changes are committed, pushed, and verified after deploy.
 
 **Relevant file:** `main/src/App.jsx`
 
 ---
 
-## 6. Medium-Low: Images Need Explicit Loading Treatment
+## 6. Partially Addressed in Current Working Tree: Images Need Explicit Loading Treatment
 
-The hero image, project logos, experience logos, and resume preview generally lack intrinsic dimensions. Several below-the-fold images are also loaded eagerly.
+At the baseline, the hero image, project logos, experience logos, and resume preview generally lacked intrinsic dimensions, and several below-the-fold images loaded eagerly.
 
-Recommended treatment:
+The current uncommitted working tree addresses the loading policy portion:
+
+- Homepage profile and resume preview images use `loading="eager"`,
+  `fetchPriority="high"`, and `decoding="async"`.
+- Repeated logos and provider icons use `loading="lazy"` and
+  `decoding="async"`.
+- `main/src/App.test.jsx` includes assertions for the image-loading behavior
+  that is most important to route rendering.
+
+Recommended remaining treatment:
 
 - Provide `width` and `height`, or a stable aspect ratio, for layout reservation.
-- Lazy-load below-the-fold assets.
-- Keep the homepage hero eager and consider `fetchPriority="high"`.
 - Evaluate WebP or AVIF for large photographic assets.
+- Run a desktop and narrow-mobile browser pass before treating this as fully
+  visually verified.
 
 **Relevant files:**
 
@@ -430,11 +520,12 @@ The repository already has unusually mature automation for a personal portfolio:
 Recommended additions, in descending order of value:
 
 1. `axe` checks for every top-level route.
-2. A deployed-route smoke check proving unknown URLs return HTTP 404.
-3. Synchronization tests for sitemap, JSON-LD, AI artifacts, and framework versions.
-4. A rendered-HTML test confirming route-specific metadata after prerendering.
-5. One mobile and one desktop visual-regression pass.
-6. A modest bundle-size or Lighthouse budget.
+2. A deployed-route smoke check proving unknown URLs return HTTP 404 and
+   canonical route redirects still land on route-specific prerendered shells.
+3. One mobile and one desktop visual-regression pass.
+4. A modest bundle-size or Lighthouse budget.
+5. Wire content/AI discovery/CSP/GA4 focused checks into release validation as
+   public surfaces evolve.
 
 ---
 
@@ -463,15 +554,17 @@ That would make the case studies read more like senior engineering narratives an
 
 # Recommended Execution Order
 
-1. Pre-render canonical routes so initial HTML contains route-specific metadata.
-2. Generate public documentation and AI artifacts from canonical data.
-3. Add route-level lazy loading and explicit image-loading behavior.
-4. Add accessibility and performance regression checks.
-5. Add a concise privacy disclosure and review Formspree spam controls.
-6. Address the Analytics CSP allowlist and lowercase resume canonicalization findings from the post-deploy validation.
+1. Finish review/release validation for the current route lazy-loading and
+   image-loading working-tree changes.
+2. Add accessibility, visual, and performance regression checks.
+3. Add a concise privacy disclosure and review Formspree spam controls.
+4. Address the analytics CSP allowlist, trailing-slash canonicalization, and
+   lowercase resume canonicalization findings from deployed validation.
+5. Add `generate:public -- --check` and AI discovery validation to the release
+   path.
 
 ---
 
 # Final Assessment
 
-After the remaining architectural and documentation work, the repository will not merely look polished as a portfolio; it will demonstrate the same operational rigor and reliability mindset that the site presents as a professional specialty.
+As the remaining operational polish lands, the repository will not merely look polished as a portfolio; it will demonstrate the same operational rigor and reliability mindset that the site presents as a professional specialty.

--- a/main/src/App.jsx
+++ b/main/src/App.jsx
@@ -1,16 +1,31 @@
+import React, { Suspense, lazy } from "react"
 import { Navigate, Routes, Route } from "react-router-dom"
 import Home from "./pages/Home.jsx"
-import Resume from "./pages/Resume.jsx"
-import Contact from "./pages/Contact.jsx"
-import CaseStudies from "./pages/CaseStudies.jsx"
-import CaseStudy from "./pages/CaseStudy.jsx"
-import Experience from "./pages/Experience.jsx"
-import Projects from "./pages/Projects.jsx"
-import NotFound from "./pages/NotFound.jsx"
 import Navbar from "./components/Navbar.jsx"
 import Seo from "./components/Seo.jsx"
-import React from "react"
 import usePageTracking from "./hooks/usePageTracking.jsx"
+
+const Resume = lazy(() => import("./pages/Resume.jsx"))
+const Contact = lazy(() => import("./pages/Contact.jsx"))
+const CaseStudies = lazy(() => import("./pages/CaseStudies.jsx"))
+const CaseStudy = lazy(() => import("./pages/CaseStudy.jsx"))
+const Experience = lazy(() => import("./pages/Experience.jsx"))
+const Projects = lazy(() => import("./pages/Projects.jsx"))
+const NotFound = lazy(() => import("./pages/NotFound.jsx"))
+
+function RouteLoadingFallback() {
+  return (
+    <div className="flex min-h-[18rem] items-center justify-center px-4 py-16">
+      <p
+        role="status"
+        aria-live="polite"
+        className="rounded-md border border-slate-900/10 bg-white/70 px-4 py-2 text-sm font-bold text-slate-600 shadow-sm"
+      >
+        Loading page...
+      </p>
+    </div>
+  )
+}
 
 function App() {
   usePageTracking()
@@ -19,22 +34,24 @@ function App() {
       <Seo />
       <Navbar />
       <div className="flex-1 overflow-auto">
-        <Routes>
-          <Route caseSensitive path="/" element={<Home />} />
-          <Route caseSensitive path="/resume" element={<Resume />} />
-          <Route caseSensitive path="/contact" element={<Contact />} />
-          <Route caseSensitive path="/case-studies" element={<CaseStudies />} />
-          <Route caseSensitive path="/case-studies/:slug" element={<CaseStudy />} />
-          <Route caseSensitive path="/experience" element={<Experience />} />
-          <Route caseSensitive path="/projects" element={<Projects />} />
-          <Route caseSensitive path="/Resume" element={<Navigate to="/resume" replace />} />
-          <Route caseSensitive path="/Contact" element={<Navigate to="/contact" replace />} />
-          <Route caseSensitive path="/CaseStudies" element={<Navigate to="/case-studies" replace />} />
-          <Route caseSensitive path="/Case-Studies" element={<Navigate to="/case-studies" replace />} />
-          <Route caseSensitive path="/Experience" element={<Navigate to="/experience" replace />} />
-          <Route caseSensitive path="/Projects" element={<Navigate to="/projects" replace />} />
-          <Route path="*" element={<NotFound />} />
-        </Routes>
+        <Suspense fallback={<RouteLoadingFallback />}>
+          <Routes>
+            <Route caseSensitive path="/" element={<Home />} />
+            <Route caseSensitive path="/resume" element={<Resume />} />
+            <Route caseSensitive path="/contact" element={<Contact />} />
+            <Route caseSensitive path="/case-studies" element={<CaseStudies />} />
+            <Route caseSensitive path="/case-studies/:slug" element={<CaseStudy />} />
+            <Route caseSensitive path="/experience" element={<Experience />} />
+            <Route caseSensitive path="/projects" element={<Projects />} />
+            <Route caseSensitive path="/Resume" element={<Navigate to="/resume" replace />} />
+            <Route caseSensitive path="/Contact" element={<Navigate to="/contact" replace />} />
+            <Route caseSensitive path="/CaseStudies" element={<Navigate to="/case-studies" replace />} />
+            <Route caseSensitive path="/Case-Studies" element={<Navigate to="/case-studies" replace />} />
+            <Route caseSensitive path="/Experience" element={<Navigate to="/experience" replace />} />
+            <Route caseSensitive path="/Projects" element={<Navigate to="/projects" replace />} />
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </Suspense>
       </div>
     </div>
   )

--- a/main/src/App.test.jsx
+++ b/main/src/App.test.jsx
@@ -68,6 +68,15 @@ const clickWithoutNavigation = async (user, element) => {
   await user.click(element)
 }
 
+const expectImagePolicy = (image, { loading, fetchPriority }) => {
+  expect(image).toHaveAttribute("loading", loading)
+  expect(image).toHaveAttribute("decoding", "async")
+
+  if (fetchPriority) {
+    expect(image).toHaveAttribute("fetchpriority", fetchPriority)
+  }
+}
+
 beforeEach(() => {
   formspreeSubmitMock.mockClear()
   formspreeMockState.current = {
@@ -96,43 +105,53 @@ afterEach(() => {
 })
 
 describe("App routes", () => {
-  it("renders the home route", () => {
+  it("renders the home route", async () => {
     renderRoute("/")
 
     expect(
-      screen.getByRole("heading", { name: /waffy ahmed/i })
+      await screen.findByRole("heading", { name: /waffy ahmed/i })
     ).toBeInTheDocument()
     expect(
       screen.getByRole("link", { name: /download resume/i })
     ).toHaveAttribute("href", "/waffyAhmedResume.pdf")
+    expectImagePolicy(
+      screen.getByRole("img", { name: /waffy ahmed/i }),
+      {
+        loading: "eager",
+        fetchPriority: "high",
+      }
+    )
   })
 
-  it("renders the projects route", () => {
+  it("renders the projects route", async () => {
     renderRoute("/projects")
 
     expect(
-      screen.getByRole("heading", {
+      await screen.findByRole("heading", {
         name: /practical builds for real workflows/i,
       })
     ).toBeInTheDocument()
     expect(
       screen.getAllByRole("heading", { name: /cdc data reconciliation/i })
     ).not.toHaveLength(0)
+    expectImagePolicy(document.querySelector(`img[src="${projects[0].logo}"]`), {
+      loading: "lazy",
+    })
   })
 
-  it("renders the experience route", () => {
+  it("renders the experience route", async () => {
     renderRoute("/experience")
 
     expect(
-      screen.getByRole("heading", { name: /work experience/i })
+      await screen.findByRole("heading", { name: /work experience/i })
     ).toBeInTheDocument()
   })
 
-  it("renders the case studies route", () => {
+  it("renders the case studies route", async () => {
     renderRoute("/case-studies")
 
     expect(
-      screen.getByRole("heading", { name: /selected engineering case studies/i })
+      await screen.findByRole("heading", { name: /selected engineering case studies/i })
     ).toBeInTheDocument()
     const [firstCaseStudyLink] = screen.getAllByRole("link", {
       name: /read case study/i,
@@ -143,11 +162,11 @@ describe("App routes", () => {
     )
   })
 
-  it("renders a case study detail route", () => {
+  it("renders a case study detail route", async () => {
     renderRoute("/case-studies/kubernetes-autoscaling")
 
     expect(
-      screen.getByRole("heading", {
+      await screen.findByRole("heading", {
         name: /kubernetes autoscaling for transaction-critical services/i,
       })
     ).toBeInTheDocument()
@@ -206,6 +225,9 @@ describe("App routes", () => {
     vi.stubEnv("VITE_GA_MEASUREMENT_ID", "G-TEST123")
     renderRoute("/projects")
 
+    await screen.findByRole("heading", {
+      name: /practical builds for real workflows/i,
+    })
     await waitFor(() =>
       expect(document.getElementById("google-analytics-script")).toBeInTheDocument()
     )
@@ -272,14 +294,14 @@ describe("App routes", () => {
     vi.stubEnv("VITE_GA_MEASUREMENT_ID", "G-TEST123")
     renderRoute("/")
 
+    const downloadResumeLink = await screen.findByRole("link", {
+      name: /download resume/i,
+    })
     await waitFor(() =>
       expect(document.getElementById("google-analytics-script")).toBeInTheDocument()
     )
 
-    await clickWithoutNavigation(
-      user,
-      screen.getByRole("link", { name: /download resume/i })
-    )
+    await clickWithoutNavigation(user, downloadResumeLink)
     await clickWithoutNavigation(
       user,
       screen.getByRole("link", { name: /linkedin/i })
@@ -314,11 +336,12 @@ describe("App routes", () => {
     vi.stubEnv("VITE_GA_MEASUREMENT_ID", "G-TEST123")
     renderRoute("/contact")
 
+    const firstNameInput = await screen.findByLabelText(/first name/i)
     await waitFor(() =>
       expect(document.getElementById("google-analytics-script")).toBeInTheDocument()
     )
 
-    await user.type(screen.getByLabelText(/first name/i), "Waffy")
+    await user.type(firstNameInput, "Waffy")
     await user.type(screen.getByLabelText(/last name/i), "Ahmed")
     await user.type(screen.getByLabelText(/email/i), "waffy@example.com")
     await user.type(screen.getByLabelText(/message/i), "Hello from the test.")
@@ -342,11 +365,12 @@ describe("App routes", () => {
     vi.stubEnv("VITE_GA_MEASUREMENT_ID", "G-TEST123")
     renderRoute("/contact")
 
+    const firstNameInput = await screen.findByLabelText(/first name/i)
     await waitFor(() =>
       expect(document.getElementById("google-analytics-script")).toBeInTheDocument()
     )
 
-    await user.type(screen.getByLabelText(/first name/i), "Waffy")
+    await user.type(firstNameInput, "Waffy")
     await user.type(screen.getByLabelText(/last name/i), "Ahmed")
     await user.type(screen.getByLabelText(/email/i), "waffy@example.com")
     await user.type(
@@ -370,6 +394,7 @@ describe("App routes", () => {
     }
     renderRoute("/contact")
 
+    await screen.findByText(/thank you for your message/i)
     const successStatus = screen.getByRole("status")
 
     expect(successStatus).toHaveAttribute("aria-live", "polite")
@@ -390,7 +415,7 @@ describe("App routes", () => {
     }
     renderRoute("/contact")
 
-    const submissionAlert = screen.getByRole("alert")
+    const submissionAlert = await screen.findByRole("alert")
 
     expect(submissionAlert).toHaveTextContent(/message could not be sent/i)
     expect(submissionAlert).toHaveAttribute("tabindex", "-1")
@@ -517,26 +542,32 @@ describe("App routes", () => {
     }
   })
 
-  it("renders the resume route", () => {
+  it("renders the resume route", async () => {
     renderRoute("/resume")
 
-    expect(screen.getByRole("link", { name: /open pdf/i })).toHaveAttribute(
+    expect(await screen.findByRole("link", { name: /open pdf/i })).toHaveAttribute(
       "href",
       "/waffyAhmedResume.pdf"
     )
-    expect(
-      screen.getByRole("img", { name: /preview of waffy ahmed's resume/i })
-    ).toHaveAttribute("src", "/resume-preview.png")
+    const resumePreview = screen.getByRole("img", {
+      name: /preview of waffy ahmed's resume/i,
+    })
+
+    expect(resumePreview).toHaveAttribute("src", "/resume-preview.png")
+    expectImagePolicy(resumePreview, {
+      loading: "eager",
+      fetchPriority: "high",
+    })
     expect(
       screen.queryByText(/your browser cannot display this pdf inline/i)
     ).not.toBeInTheDocument()
   })
 
-  it("renders the contact route", () => {
+  it("renders the contact route", async () => {
     renderRoute("/contact")
 
     expect(
-      screen.getByRole("heading", { name: /let's connect/i })
+      await screen.findByRole("heading", { name: /let's connect/i })
     ).toBeInTheDocument()
     expect(
       screen.getByRole("heading", { name: /contact form/i })
@@ -573,7 +604,7 @@ describe("App routes", () => {
     renderRoute("/missing-page")
 
     expect(
-      screen.getByRole("heading", { name: /page not found/i })
+      await screen.findByRole("heading", { name: /page not found/i })
     ).toBeInTheDocument()
     expect(screen.getByRole("link", { name: /go home/i })).toHaveAttribute(
       "href",
@@ -630,6 +661,7 @@ describe("App routes", () => {
     })
     renderRoute("/experience")
 
+    await screen.findByRole("heading", { name: /work experience/i })
     expect(
       screen.queryByRole("region", { name: /experience details/i })
     ).not.toBeInTheDocument()

--- a/main/src/components/DeployDates.jsx
+++ b/main/src/components/DeployDates.jsx
@@ -97,6 +97,8 @@ function DeployDates({ first }) {
                   src={provider.icon}
                   alt=""
                   aria-hidden="true"
+                  loading="lazy"
+                  decoding="async"
                   className="h-5 w-5 opacity-90"
                 />
               </button>

--- a/main/src/components/ExperienceCard.jsx
+++ b/main/src/components/ExperienceCard.jsx
@@ -211,6 +211,8 @@ const ExperienceCard = ({
               src={logo}
               alt=""
               aria-hidden="true"
+              loading="lazy"
+              decoding="async"
               className={logoImageClass}
             />
           </div>

--- a/main/src/components/ProjectCard.jsx
+++ b/main/src/components/ProjectCard.jsx
@@ -164,6 +164,8 @@ function ProjectCard({ id, title, techStack, bullets, github, logo }) {
               src={logo}
               alt=""
               aria-hidden="true"
+              loading="lazy"
+              decoding="async"
               className="max-h-36 max-w-[78%] object-contain"
             />
           </div>

--- a/main/src/pages/CaseStudies.jsx
+++ b/main/src/pages/CaseStudies.jsx
@@ -63,6 +63,8 @@ function CaseStudyCard({ caseStudy, featured = false }) {
               src={caseStudy.logo}
               alt=""
               aria-hidden="true"
+              loading="lazy"
+              decoding="async"
               className="max-h-full max-w-full object-contain"
             />
           </span>

--- a/main/src/pages/CaseStudy.jsx
+++ b/main/src/pages/CaseStudy.jsx
@@ -89,6 +89,8 @@ function CaseStudy() {
                   src={caseStudy.logo}
                   alt=""
                   aria-hidden="true"
+                  loading="lazy"
+                  decoding="async"
                   className="max-h-full max-w-full object-contain"
                 />
               </span>

--- a/main/src/pages/Home.jsx
+++ b/main/src/pages/Home.jsx
@@ -178,6 +178,9 @@ function Home() {
                   <img
                     src={profile.profilePicture}
                     alt={profile.name}
+                    loading="eager"
+                    fetchPriority="high"
+                    decoding="async"
                     className="h-[30rem] w-full rounded-2xl object-cover object-center"
                   />
                 </div>

--- a/main/src/pages/Resume.jsx
+++ b/main/src/pages/Resume.jsx
@@ -67,6 +67,9 @@ function Resume() {
             <img
               src={resume.preview}
               alt="Preview of Waffy Ahmed's resume"
+              loading="eager"
+              fetchPriority="high"
+              decoding="async"
               className="h-auto w-full rounded-md"
             />
           </a>

--- a/scripts/check-deployed-security-headers.py
+++ b/scripts/check-deployed-security-headers.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+import argparse
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+
+# Keep this baseline independent from netlify.toml. The config defines the
+# intended deployment, while these requirements prevent both from drifting to
+# a weakened policy together.
+REQUIRED_HEADER_VALUES = {
+    "x-content-type-options": "nosniff",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+}
+
+REQUIRED_HEADER_FRAGMENTS = {
+    "permissions-policy": (
+        "camera=()",
+        "microphone=()",
+        "geolocation=()",
+        "payment=()",
+        "usb=()",
+    ),
+}
+
+REQUIRED_CSP_DIRECTIVES = {
+    "default-src": ("'self'",),
+    "base-uri": ("'self'",),
+    "object-src": ("'none'",),
+    "frame-ancestors": ("'none'",),
+    "script-src": ("'self'", "https://www.googletagmanager.com"),
+    "connect-src": (
+        "'self'",
+        "https://formspree.io",
+        "https://www.google-analytics.com",
+        "https://*.google-analytics.com",
+        "https://analytics.google.com",
+        "https://*.analytics.google.com",
+    ),
+    "img-src": (
+        "'self'",
+        "data:",
+        "https://www.googletagmanager.com",
+        "https://www.google-analytics.com",
+        "https://*.google-analytics.com",
+    ),
+    "style-src": ("'self'", "'unsafe-inline'"),
+    "font-src": ("'self'", "data:"),
+    "form-action": ("'self'", "https://formspree.io"),
+    "frame-src": ("'none'",),
+    "upgrade-insecure-requests": (),
+}
+
+
+def load_expected_headers(repo_root):
+    netlify_toml = repo_root / "netlify.toml"
+    config = tomllib.loads(netlify_toml.read_text(encoding="utf-8"))
+    header_blocks = config.get("headers", [])
+
+    for block in header_blocks:
+        if block.get("for") == "/*":
+            values = block.get("values", {})
+            if not values:
+                raise ValueError("netlify.toml has an empty [[headers]] block for /*")
+            return values
+
+    raise ValueError("netlify.toml is missing the global [[headers]] block for /*")
+
+
+def fetch_headers(site_url, timeout, retries, retry_delay):
+    result = subprocess.run(
+        [
+            "curl",
+            "--silent",
+            "--show-error",
+            "--location",
+            "--head",
+            "--retry",
+            str(retries),
+            "--retry-delay",
+            str(retry_delay),
+            "--connect-timeout",
+            "10",
+            "--max-time",
+            str(timeout),
+            "--dump-header",
+            "-",
+            "--output",
+            "/dev/null",
+            "--write-out",
+            "\n__HTTP_STATUS__:%{http_code}\n",
+            site_url,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    if result.returncode != 0:
+        raise RuntimeError(f"Could not fetch {site_url}: {result.stderr.strip()}")
+
+    output = result.stdout.replace("\r\n", "\n").replace("\r", "\n")
+    status_match = re.search(r"\n__HTTP_STATUS__:(\d{3})\n?$", output)
+    if not status_match:
+        raise RuntimeError("Could not determine HTTP status from curl output.")
+
+    status_code = status_match.group(1)
+    header_output = output[: status_match.start()]
+    if status_code != "200":
+        raise RuntimeError(
+            f"Expected HTTP 200 from {site_url}, got {status_code}.\n{header_output.strip()}"
+        )
+
+    header_blocks = [block for block in header_output.split("\n\n") if block.strip()]
+    if not header_blocks:
+        raise RuntimeError("Could not parse response headers from curl output.")
+
+    headers = {}
+    for line in header_blocks[-1].splitlines()[1:]:
+        if ":" not in line:
+            continue
+        name, value = line.split(":", 1)
+        headers.setdefault(name.lower(), []).append(value.strip())
+
+    return headers
+
+
+def get_header_values(headers, name):
+    return headers.get(name.lower(), [])
+
+
+def parse_csp_directives(policy):
+    directives = {}
+    duplicate_directives = set()
+    for declaration in policy.split(";"):
+        parts = declaration.strip().split()
+        if parts:
+            directive_name = parts[0].lower()
+            if directive_name in directives:
+                duplicate_directives.add(directive_name)
+                continue
+            directives[directive_name] = parts[1:]
+    return directives, duplicate_directives
+
+
+def is_sha256_token(token):
+    return token.startswith("'sha256-") and token.endswith("'")
+
+
+def validate_minimum_policy(headers):
+    normalized_headers = {name.lower(): value for name, value in headers.items()}
+    failures = []
+
+    for header_name, required_value in REQUIRED_HEADER_VALUES.items():
+        actual_value = normalized_headers.get(header_name)
+        if actual_value != required_value:
+            failures.append(
+                f"{header_name} must be {required_value!r}; got {actual_value or '<missing>'!r}."
+            )
+
+    for header_name, required_fragments in REQUIRED_HEADER_FRAGMENTS.items():
+        actual_value = normalized_headers.get(header_name)
+        if actual_value is None:
+            failures.append(f"Missing required {header_name} header.")
+            continue
+
+        for fragment in required_fragments:
+            if fragment not in actual_value:
+                failures.append(f"{header_name} is missing required fragment {fragment!r}.")
+
+    csp = normalized_headers.get("content-security-policy")
+    if csp is None:
+        failures.append("Missing required content-security-policy header.")
+        return failures
+
+    csp_directives, duplicate_directives = parse_csp_directives(csp)
+    for directive_name in sorted(duplicate_directives):
+        failures.append(
+            f"Content-Security-Policy contains duplicate {directive_name} directives."
+        )
+
+    unexpected_directives = sorted(
+        set(csp_directives).difference(REQUIRED_CSP_DIRECTIVES)
+    )
+    for directive_name in unexpected_directives:
+        failures.append(
+            f"Content-Security-Policy contains unexpected directive {directive_name}."
+        )
+
+    for directive_name, required_tokens in REQUIRED_CSP_DIRECTIVES.items():
+        actual_tokens = csp_directives.get(directive_name)
+        if actual_tokens is None:
+            failures.append(f"Content-Security-Policy is missing {directive_name}.")
+            continue
+
+        for token in required_tokens:
+            if token not in actual_tokens:
+                failures.append(
+                    f"Content-Security-Policy {directive_name} is missing required token {token!r}."
+                )
+
+        unexpected_tokens = [
+            token
+            for token in actual_tokens
+            if token not in required_tokens
+            and not (directive_name == "script-src" and is_sha256_token(token))
+        ]
+        for token in unexpected_tokens:
+            failures.append(
+                f"Content-Security-Policy {directive_name} contains unexpected token {token!r}."
+            )
+
+    script_tokens = csp_directives.get("script-src", [])
+    if not any(is_sha256_token(token) for token in script_tokens):
+        failures.append("Content-Security-Policy script-src is missing an inline SHA-256 hash.")
+
+    return failures
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compare deployed security headers against netlify.toml."
+    )
+    parser.add_argument(
+        "--repo",
+        default=".",
+        help="Repository root containing netlify.toml.",
+    )
+    parser.add_argument(
+        "--site-url",
+        default="https://waffy.dev/",
+        help="Deployed site URL to check.",
+    )
+    parser.add_argument("--timeout", type=int, default=30)
+    parser.add_argument("--retries", type=int, default=3)
+    parser.add_argument("--retry-delay", type=int, default=5)
+    args = parser.parse_args()
+
+    repo_root = Path(args.repo).resolve()
+    expected_headers = load_expected_headers(repo_root)
+    policy_failures = validate_minimum_policy(expected_headers)
+    if policy_failures:
+        print(
+            "netlify.toml security policy does not meet the required baseline.",
+            file=sys.stderr,
+        )
+        for failure in policy_failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+
+    actual_headers = fetch_headers(args.site_url, args.timeout, args.retries, args.retry_delay)
+
+    failures = []
+    for header_name, expected_value in expected_headers.items():
+        actual_values = get_header_values(actual_headers, header_name)
+        if actual_values != [expected_value]:
+            failures.append((header_name, expected_value, actual_values))
+
+    if failures:
+        print("Production security headers do not match netlify.toml.", file=sys.stderr)
+        for header_name, expected_value, actual_values in failures:
+            print(f"\nUnexpected {header_name} header.", file=sys.stderr)
+            print(f"Expected: {expected_value}", file=sys.stderr)
+            if not actual_values:
+                print("Actual:   <missing>", file=sys.stderr)
+            else:
+                print(f"Actual ({len(actual_values)} value(s)):", file=sys.stderr)
+                for actual_value in actual_values:
+                    print(f"- {actual_value}", file=sys.stderr)
+        return 1
+
+    checked = ", ".join(expected_headers.keys())
+    print(f"Production security headers match netlify.toml: {checked}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_deployed_security_headers.py
+++ b/scripts/test_deployed_security_headers.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+import io
+import runpy
+import subprocess
+import sys
+import types
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CHECKER_PATH = REPO_ROOT / "scripts" / "check-deployed-security-headers.py"
+CHECKER = types.SimpleNamespace()
+CHECKER.__dict__.update(runpy.run_path(str(CHECKER_PATH)))
+
+
+def curl_response(header_lines):
+    lines = ["HTTP/1.1 200 OK", *header_lines, "", "__HTTP_STATUS__:200", ""]
+    return "\r\n".join(lines)
+
+
+class DeployedSecurityHeadersTest(unittest.TestCase):
+    def setUp(self):
+        self.expected_headers = CHECKER.load_expected_headers(REPO_ROOT)
+
+    def run_checker(self, extra_header_lines=()):
+        expected_lines = [
+            f"{name}: {value}" for name, value in self.expected_headers.items()
+        ]
+        result = subprocess.CompletedProcess(
+            args=["curl"],
+            returncode=0,
+            stdout=curl_response([*extra_header_lines, *expected_lines]),
+            stderr="",
+        )
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        argv = [
+            "check-deployed-security-headers.py",
+            "--repo",
+            str(REPO_ROOT),
+            "--site-url",
+            "https://example.test/",
+            "--retries",
+            "0",
+        ]
+
+        with (
+            patch.object(CHECKER.subprocess, "run", return_value=result),
+            patch.object(sys, "argv", argv),
+            redirect_stdout(stdout),
+            redirect_stderr(stderr),
+        ):
+            return_code = CHECKER.main()
+
+        return return_code, stdout.getvalue(), stderr.getvalue()
+
+    def test_matching_headers_pass(self):
+        return_code, stdout, stderr = self.run_checker()
+
+        self.assertEqual(return_code, 0)
+        self.assertIn("match netlify.toml", stdout)
+        self.assertEqual(stderr, "")
+
+    def test_minimum_policy_rejects_permissive_csp_tokens(self):
+        headers = dict(self.expected_headers)
+        headers["Content-Security-Policy"] = headers["Content-Security-Policy"].replace(
+            "form-action 'self' https://formspree.io",
+            "form-action 'self' * https://formspree.io",
+        )
+
+        failures = CHECKER.validate_minimum_policy(headers)
+
+        self.assertIn(
+            "Content-Security-Policy form-action contains unexpected token '*'.",
+            failures,
+        )
+
+    def test_minimum_policy_rejects_duplicate_csp_directives(self):
+        headers = dict(self.expected_headers)
+        headers["Content-Security-Policy"] = (
+            "script-src *; " + headers["Content-Security-Policy"]
+        )
+
+        failures = CHECKER.validate_minimum_policy(headers)
+
+        self.assertIn(
+            "Content-Security-Policy contains duplicate script-src directives.",
+            failures,
+        )
+        self.assertIn(
+            "Content-Security-Policy script-src is missing required token \"'self'\".",
+            failures,
+        )
+
+    def test_minimum_policy_rejects_unexpected_csp_directives(self):
+        headers = dict(self.expected_headers)
+        headers["Content-Security-Policy"] += "; worker-src *"
+
+        failures = CHECKER.validate_minimum_policy(headers)
+
+        self.assertIn(
+            "Content-Security-Policy contains unexpected directive worker-src.",
+            failures,
+        )
+
+    def test_duplicate_expected_headers_fail(self):
+        for header_name, expected_value in self.expected_headers.items():
+            duplicate_value = (
+                "default-src 'none'"
+                if header_name.lower() == "content-security-policy"
+                else expected_value
+            )
+
+            with self.subTest(header=header_name):
+                return_code, stdout, stderr = self.run_checker(
+                    (f"{header_name}: {duplicate_value}",)
+                )
+
+                self.assertEqual(return_code, 1)
+                self.assertEqual(stdout, "")
+                self.assertIn(f"Unexpected {header_name} header", stderr)
+                self.assertIn("Actual (2 value(s))", stderr)
+
+    def test_duplicate_unrelated_header_is_ignored(self):
+        return_code, stdout, stderr = self.run_checker(
+            ("Set-Cookie: first=value", "Set-Cookie: second=value")
+        )
+
+        self.assertEqual(return_code, 0)
+        self.assertIn("match netlify.toml", stdout)
+        self.assertEqual(stderr, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add route-level lazy loading and explicit image-loading policies with deterministic performance checks
- derive deployed security-header expectations from `netlify.toml` and harden CSP validation against duplicate or unexpected directives
- add focused repo-maintenance skills and reconcile the repository audit with current validation evidence

## Verification
- `bash .codex/skills/portfolio-release-qa/scripts/portfolio_preflight.sh /Users/waffyahmed/Downloads/personalWebsite`
- `python3 scripts/test_deployed_security_headers.py` (6 tests)
- `node --test .codex/skills/portfolio-performance-auditor/scripts/test_frontend_performance.mjs` (6 tests)
- frontend performance policy check
- CSP JSON-LD hash check
- GitHub workflow YAML parse
- local preview smoke checks for app routes, discovery artifacts, portfolio JSON, and resume PDF
- not run: post-deploy live header validation, which requires this commit to be deployed
