### PR TITLE
Add semantic production release governance

### DIFF
--- a/.github/workflows/release-on-deploy.yml
+++ b/.github/workflows/release-on-deploy.yml
@@ -165,6 +165,7 @@ jobs:
               body,
               draft: false,
               prerelease: false,
+              make_latest: false,
               generate_release_notes: true,
             });
 

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -1,0 +1,240 @@
+name: Publish semantic production release
+
+"on":
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Core release version from main/package.json (for example 0.1.0)
+        required: true
+        type: string
+      target_commit:
+        description: Exact 40-character SHA of the ready Netlify production commit
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: semantic-production-release
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Verify and publish semantic release
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out target commit and main history
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.target_commit }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22.22.3
+
+      - name: Verify target and authoritative version
+        id: target
+        env:
+          REQUESTED_VERSION: ${{ inputs.version }}
+          TARGET_COMMIT: ${{ inputs.target_commit }}
+        run: |
+          set -euo pipefail
+
+          case "$TARGET_COMMIT" in
+            [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]) ;;
+            *) echo "target_commit must be a lowercase 40-character SHA." >&2; exit 1 ;;
+          esac
+
+          git cat-file -e "${TARGET_COMMIT}^{commit}"
+          git merge-base --is-ancestor "$TARGET_COMMIT" origin/main
+          test "$(git rev-parse HEAD)" = "$TARGET_COMMIT"
+          node main/scripts/release-version.mjs "$REQUESTED_VERSION"
+          echo "tag=v${REQUESTED_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify current Netlify production deploy
+        id: netlify
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+          TARGET_COMMIT: ${{ inputs.target_commit }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${NETLIFY_AUTH_TOKEN}" ] || [ -z "${NETLIFY_SITE_ID}" ]; then
+            echo "NETLIFY_AUTH_TOKEN and NETLIFY_SITE_ID secrets are required." >&2
+            exit 1
+          fi
+
+          deploy_json="$(curl -fsS \
+            -H "Authorization: Bearer ${NETLIFY_AUTH_TOKEN}" \
+            "https://api.netlify.com/api/v1/sites/${NETLIFY_SITE_ID}/deploys?production=true&per_page=1")"
+          deploy_state="$(printf '%s' "$deploy_json" | python3 -c 'import json,sys; deploys=json.load(sys.stdin); print((deploys[0] if deploys else {}).get("state", ""))')"
+          deploy_commit="$(printf '%s' "$deploy_json" | python3 -c 'import json,sys; deploys=json.load(sys.stdin); print((deploys[0] if deploys else {}).get("commit_ref", ""))')"
+          deploy_id="$(printf '%s' "$deploy_json" | python3 -c 'import json,sys; deploys=json.load(sys.stdin); print((deploys[0] if deploys else {}).get("id", ""))')"
+          deploy_url="$(printf '%s' "$deploy_json" | python3 -c 'import json,sys; deploys=json.load(sys.stdin); deploy=deploys[0] if deploys else {}; print(deploy.get("deploy_ssl_url") or deploy.get("ssl_url") or "")')"
+
+          test "$deploy_state" = ready
+          test "$deploy_commit" = "$TARGET_COMMIT"
+          test -n "$deploy_id"
+          test -n "$deploy_url"
+          echo "id=$deploy_id" >> "$GITHUB_OUTPUT"
+          echo "url=$deploy_url" >> "$GITHUB_OUTPUT"
+
+      - name: Require matching deployment provenance release
+        id: deploy_release
+        uses: actions/github-script@v9
+        env:
+          TARGET_COMMIT: ${{ inputs.target_commit }}
+        with:
+          script: |
+            const releases = await github.paginate(github.rest.repos.listReleases, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100,
+            });
+            const release = releases.find((candidate) => (
+              !candidate.draft
+              && candidate.tag_name.startsWith('deploy-')
+              && candidate.target_commitish === process.env.TARGET_COMMIT
+            ));
+            if (!release) {
+              core.setFailed(`No published deploy-* release targets ${process.env.TARGET_COMMIT}.`);
+              return;
+            }
+            core.setOutput('tag', release.tag_name);
+            core.setOutput('url', release.html_url);
+
+      - name: Reject semantic collisions and establish release range
+        id: semantic_state
+        uses: actions/github-script@v9
+        env:
+          TARGET_COMMIT: ${{ inputs.target_commit }}
+          REQUESTED_VERSION: ${{ inputs.version }}
+          RELEASE_TAG: ${{ steps.target.outputs.tag }}
+        with:
+          script: |
+            const { execFileSync } = require('node:child_process');
+            const versionPattern = /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+            const compare = (left, right) => {
+              const leftParts = left.slice(1).split('.').map(Number);
+              const rightParts = right.slice(1).split('.').map(Number);
+              for (let index = 0; index < leftParts.length; index += 1) {
+                if (leftParts[index] !== rightParts[index]) return leftParts[index] - rightParts[index];
+              }
+              return 0;
+            };
+            const target = process.env.TARGET_COMMIT;
+            const requestedTag = process.env.RELEASE_TAG;
+            const releases = await github.paginate(github.rest.repos.listReleases, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100,
+            });
+            const tags = execFileSync('git', ['tag', '--list', 'v*'], { encoding: 'utf8' })
+              .split('\n').filter(Boolean).filter((tag) => versionPattern.test(tag));
+            const semanticReleases = releases.filter((release) => versionPattern.test(release.tag_name));
+            const releasesByTag = new Map(semanticReleases.map((release) => [release.tag_name, release]));
+
+            for (const tag of tags) {
+              const release = releasesByTag.get(tag);
+              if (!release) throw new Error(`Semantic tag ${tag} has no GitHub release (tag-only collision).`);
+              if (release.draft) throw new Error(`Semantic release ${tag} is draft.`);
+              const tagTarget = execFileSync('git', ['rev-parse', `${tag}^{commit}`], { encoding: 'utf8' }).trim();
+              if (tag === requestedTag && tagTarget !== target) throw new Error(`${tag} targets ${tagTarget}, not ${target}.`);
+            }
+            for (const release of semanticReleases) {
+              if (release.draft) throw new Error(`Semantic release ${release.tag_name} is draft.`);
+              if (!tags.includes(release.tag_name)) throw new Error(`Semantic release ${release.tag_name} has no tag.`);
+            }
+
+            const existing = releasesByTag.get(requestedTag);
+            if (existing) {
+              const existingTarget = execFileSync('git', ['rev-parse', `${requestedTag}^{commit}`], { encoding: 'utf8' }).trim();
+              if (existingTarget !== target) throw new Error(`${requestedTag} targets ${existingTarget}, not ${target}.`);
+              core.setOutput('idempotent', 'true');
+              core.setOutput('previous_tag', '');
+              return;
+            }
+            if (tags.includes(requestedTag)) throw new Error(`${requestedTag} already exists without a published release.`);
+            if (semanticReleases.length === 0 && requestedTag !== 'v0.1.0') {
+              throw new Error('v0.1.0 must be the first semantic release.');
+            }
+            const previousTag = tags.sort(compare).at(-1) || '';
+            if (previousTag && compare(previousTag, requestedTag) >= 0) {
+              throw new Error(`${requestedTag} is not greater than existing semantic release ${previousTag}.`);
+            }
+            core.setOutput('idempotent', 'false');
+            core.setOutput('previous_tag', previousTag);
+
+      - name: Publish semantic release
+        if: steps.semantic_state.outputs.idempotent != 'true'
+        uses: actions/github-script@v9
+        env:
+          TARGET_COMMIT: ${{ inputs.target_commit }}
+          RELEASE_TAG: ${{ steps.target.outputs.tag }}
+          PREVIOUS_TAG: ${{ steps.semantic_state.outputs.previous_tag }}
+          NETLIFY_DEPLOY_ID: ${{ steps.netlify.outputs.id }}
+          NETLIFY_DEPLOY_URL: ${{ steps.netlify.outputs.url }}
+          DEPLOY_RELEASE_TAG: ${{ steps.deploy_release.outputs.tag }}
+          DEPLOY_RELEASE_URL: ${{ steps.deploy_release.outputs.url }}
+        with:
+          script: |
+            const { execFileSync } = require('node:child_process');
+            const target = process.env.TARGET_COMMIT;
+            const previousTag = process.env.PREVIOUS_TAG;
+            const commits = previousTag
+              ? execFileSync('git', ['rev-list', '--max-count=250', `${previousTag}..${target}`], { encoding: 'utf8' }).trim().split('\n').filter(Boolean)
+              : [target];
+            const pulls = new Map();
+            for (const commit of commits) {
+              const associated = await github.paginate(github.rest.repos.listPullRequestsAssociatedWithCommit, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: commit,
+                per_page: 100,
+              });
+              associated.forEach((pull) => pulls.set(pull.number, pull));
+            }
+            const pullLines = [...pulls.values()]
+              .sort((left, right) => left.number - right.number)
+              .map((pull) => `- [#${pull.number}](${pull.html_url}) ${pull.title}`);
+            const commitUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/commit/${target}`;
+            const workflowUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const range = previousTag
+              ? `[${previousTag}...${target.slice(0, 7)}](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/compare/${previousTag}...${target})`
+              : `Initial semantic baseline at ${target.slice(0, 7)}`;
+            const body = [
+              `## Production provenance`,
+              `- Target commit: [${target}](${commitUrl})`,
+              `- Change range: ${range}`,
+              `- Semantic workflow: [run ${context.runId}](${workflowUrl})`,
+              `- Netlify production deploy: [${process.env.NETLIFY_DEPLOY_ID}](${process.env.NETLIFY_DEPLOY_URL})`,
+              `- Deployment provenance release: [${process.env.DEPLOY_RELEASE_TAG}](${process.env.DEPLOY_RELEASE_URL})`,
+              '',
+              '## Relevant pull requests',
+              ...(pullLines.length ? pullLines : ['- No pull request was associated with the selected commit range.']),
+            ].join('\n');
+            const release = await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: process.env.RELEASE_TAG,
+              target_commitish: target,
+              name: process.env.RELEASE_TAG,
+              body,
+              draft: false,
+              prerelease: false,
+              make_latest: true,
+            });
+            core.setOutput('url', release.data.html_url);
+
+      - name: Report idempotent release
+        if: steps.semantic_state.outputs.idempotent == 'true'
+        run: echo "The existing published semantic release already targets this commit."

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Run these commands from the repository root:
 | `npm run generate:public` | Regenerate public AI/discovery artifacts and README snapshots |
 | `npm run lint` | Run ESLint |
 | `npm test` | Run the Vitest test suite |
+| `npm run test:release` | Run semantic-release version validator tests |
 | `npm run test:e2e:production` | Run telemetry-safe Chromium smoke tests against production |
 | `npm run build` | Create the production build |
 | `npm run preview` | Preview the production build locally |
@@ -238,6 +239,8 @@ Release tags use the following format:
 ```text
 deploy-YYYYMMDDTHHMMSSZ-<short-sha>
 ```
+
+Curated semantic milestones use `vMAJOR.MINOR.PATCH` alongside these immutable deployment records. See [docs/release-versioning.md](./docs/release-versioning.md) for the version policy and authenticated production-release procedure.
 
 The release workflow requires the `NETLIFY_AUTH_TOKEN` and `NETLIFY_SITE_ID`
 repository secrets. Keep the token's expiration date in the

--- a/docs/release-versioning.md
+++ b/docs/release-versioning.md
@@ -1,0 +1,31 @@
+# Semantic production releases
+
+This repository keeps two independent release records:
+
+- `deploy-YYYYMMDDTHHMMSSZ-<short-sha>` releases are immutable production-deployment provenance. Every successful production merge continues to create one, and they are never retagged, deleted, or made Latest.
+- `vMAJOR.MINOR.PATCH` releases are deliberately curated milestones. They point to an already-ready Netlify production commit and are marked Latest.
+
+`main/package.json` is the authoritative semantic version. `main/package-lock.json` repeats the same value in its top-level `version` and root-package `packages[""]` fields. A release request must use the package version without a `v`; the published tag receives the `v` prefix.
+
+## Version policy
+
+Only core [SemVer 2.0](https://semver.org/) versions are accepted: `MAJOR.MINOR.PATCH`. Pre-release identifiers, build metadata, a leading `v`, and leading zeroes are rejected.
+
+Before `1.0.0`:
+
+- minor increments represent intentionally breaking or substantial curated milestones;
+- patch increments represent compatible fixes; and
+- `v0.1.0` is the selected baseline.
+
+From `1.0.0` onward, major increments represent incompatible changes, minor increments represent backwards-compatible additive changes, and patch increments represent backwards-compatible fixes.
+
+## Operator procedure
+
+1. Land the implementation with a merge commit on `main`, then wait for its **Create deployment release** workflow and Netlify production deploy to succeed.
+2. Confirm Netlify's current ready production deploy has the exact merge SHA as `commit_ref`, and confirm a non-draft `deploy-*` GitHub release targets that same SHA. Stop if production has advanced.
+3. Ensure `main/package.json` and both version fields in `main/package-lock.json` agree. Run `npm run test:release` and the normal release checks.
+4. In Actions, run **Publish semantic production release** from `main`. Provide the core version (for example `0.1.0`) and the exact 40-character merge SHA.
+5. The workflow verifies ancestry on `main`, version consistency, Netlify readiness, matching deployment provenance, existing semantic releases/tags, and monotonic version ordering before creating a release.
+6. Read back the Actions run, tag target, non-draft release, Latest status, release notes, deployment release, and Netlify deploy metadata. Record those exact links and identifiers on the tracking issue.
+
+The workflow is idempotent only when the requested semantic tag and published non-draft release already point to the supplied commit. Tag-only, draft, duplicate, non-increasing, or different-target collisions fail for manual investigation.

--- a/main/package.json
+++ b/main/package.json
@@ -21,6 +21,7 @@
     "lint": "eslint src e2e playwright.production.config.js",
     "preview": "vite preview",
     "test": "vitest run --exclude=e2e/**",
+    "test:release": "vitest run scripts/release-version.test.mjs",
     "test:e2e:production": "playwright test --config=playwright.production.config.js"
   },
   "browserslist": {

--- a/main/scripts/release-version.mjs
+++ b/main/scripts/release-version.mjs
@@ -1,0 +1,87 @@
+import { readFile } from 'node:fs/promises';
+
+export const CORE_VERSION_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+
+export function parseCoreVersion(version) {
+  if (typeof version !== 'string' || !CORE_VERSION_PATTERN.test(version)) {
+    throw new Error(`Release version must be a core MAJOR.MINOR.PATCH value: ${version}`);
+  }
+
+  return version.split('.').map(Number);
+}
+
+export function toReleaseTag(version) {
+  parseCoreVersion(version);
+  return `v${version}`;
+}
+
+export function compareCoreVersions(left, right) {
+  const leftParts = parseCoreVersion(left);
+  const rightParts = parseCoreVersion(right);
+
+  for (let index = 0; index < leftParts.length; index += 1) {
+    if (leftParts[index] !== rightParts[index]) {
+      return leftParts[index] < rightParts[index] ? -1 : 1;
+    }
+  }
+
+  return 0;
+}
+
+export function assertVersionSources(packageJson, packageLock) {
+  const packageVersion = packageJson?.version;
+  const lockVersion = packageLock?.version;
+  const rootPackageVersion = packageLock?.packages?.['']?.version;
+
+  parseCoreVersion(packageVersion);
+  parseCoreVersion(lockVersion);
+  parseCoreVersion(rootPackageVersion);
+
+  if (packageVersion !== lockVersion || packageVersion !== rootPackageVersion) {
+    throw new Error(
+      `main/package.json (${packageVersion}) and main/package-lock.json (${lockVersion}, ${rootPackageVersion}) must agree.`,
+    );
+  }
+
+  return packageVersion;
+}
+
+export function classifyReleaseCollision({ tag, targetCommit, tagTarget, release }) {
+  if (!tagTarget && !release) return 'publish';
+  if (!release) return 'tag-only';
+  if (release.draft) return 'draft';
+  if (!tagTarget) return 'release-without-tag';
+  if (tagTarget !== targetCommit) return 'different-target';
+  return release.tag_name === tag ? 'idempotent' : 'duplicate-release';
+}
+
+export async function readAuthoritativeVersion({
+  packagePath = new URL('../package.json', import.meta.url),
+  lockPath = new URL('../package-lock.json', import.meta.url),
+} = {}) {
+  const [packageJson, packageLock] = await Promise.all([
+    readFile(packagePath, 'utf8').then(JSON.parse),
+    readFile(lockPath, 'utf8').then(JSON.parse),
+  ]);
+
+  return assertVersionSources(packageJson, packageLock);
+}
+
+async function main() {
+  const requestedVersion = process.argv[2];
+  parseCoreVersion(requestedVersion);
+  const authoritativeVersion = await readAuthoritativeVersion();
+
+  if (requestedVersion !== authoritativeVersion) {
+    throw new Error(`Requested ${requestedVersion} does not match main/package.json ${authoritativeVersion}.`);
+  }
+
+  process.stdout.write(`${toReleaseTag(requestedVersion)}\n`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/main/scripts/release-version.test.mjs
+++ b/main/scripts/release-version.test.mjs
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertVersionSources,
+  classifyReleaseCollision,
+  compareCoreVersions,
+  parseCoreVersion,
+  toReleaseTag,
+} from './release-version.mjs';
+
+const matchingSources = {
+  packageJson: { version: '0.1.0' },
+  packageLock: { version: '0.1.0', packages: { '': { version: '0.1.0' } } },
+};
+
+describe('release version validation', () => {
+  it('accepts core versions and prefixes tags with v', () => {
+    expect(parseCoreVersion('12.34.56')).toEqual([12, 34, 56]);
+    expect(toReleaseTag('0.1.0')).toBe('v0.1.0');
+    expect(assertVersionSources(matchingSources.packageJson, matchingSources.packageLock)).toBe('0.1.0');
+  });
+
+  it.each(['v0.1.0', '01.2.3', '1.02.3', '1.2.03', '1.2', '1.2.3-rc.1', '1.2.3+build', '', '1.2.3.4'])(
+    'rejects non-core version %s',
+    (version) => expect(() => parseCoreVersion(version)).toThrow('core MAJOR.MINOR.PATCH'),
+  );
+
+  it('rejects package and lockfile disagreements', () => {
+    expect(() => assertVersionSources({ version: '0.1.0' }, {
+      version: '0.1.1', packages: { '': { version: '0.1.0' } },
+    })).toThrow('must agree');
+    expect(() => assertVersionSources({ version: '0.1.0' }, {
+      version: '0.1.0', packages: { '': { version: '0.1.1' } },
+    })).toThrow('must agree');
+  });
+
+  it('compares version precedence numerically', () => {
+    expect(compareCoreVersions('0.1.0', '0.1.1')).toBe(-1);
+    expect(compareCoreVersions('0.10.0', '0.2.99')).toBe(1);
+    expect(compareCoreVersions('1.0.0', '1.0.0')).toBe(0);
+  });
+
+  it('distinguishes a safe idempotent replay from collisions', () => {
+    const release = { tag_name: 'v0.1.0', draft: false };
+    expect(classifyReleaseCollision({ tag: 'v0.1.0', targetCommit: 'a'.repeat(40), tagTarget: 'a'.repeat(40), release })).toBe('idempotent');
+    expect(classifyReleaseCollision({ tag: 'v0.1.0', targetCommit: 'a'.repeat(40), tagTarget: 'b'.repeat(40), release })).toBe('different-target');
+    expect(classifyReleaseCollision({ tag: 'v0.1.0', targetCommit: 'a'.repeat(40), tagTarget: 'a'.repeat(40), release: { ...release, draft: true } })).toBe('draft');
+    expect(classifyReleaseCollision({ tag: 'v0.1.0', targetCommit: 'a'.repeat(40), tagTarget: 'a'.repeat(40), release: null })).toBe('tag-only');
+    expect(classifyReleaseCollision({ tag: 'v0.1.0', targetCommit: 'a'.repeat(40), tagTarget: 'a'.repeat(40), release: { tag_name: 'v0.1.1', draft: false } })).toBe('duplicate-release');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "generate:public": "npm --prefix main run generate:public --",
     "lint": "npm --prefix main run lint --",
     "test": "npm --prefix main run test --",
+    "test:release": "npm --prefix main run test:release --",
     "test:e2e:production": "npm --prefix main run test:e2e:production --",
     "preview": "npm --prefix main run preview --"
   }


### PR DESCRIPTION
## Summary
- add a manual, provenance-gated semantic production release workflow
- retain immutable deploy provenance releases without making them Latest
- document curated SemVer policy and add release-version unit tests

## Verification
- npm run test:release
- YAML parsing for both release workflows
- npm run lint
- npm run test
- npm run build
- git diff --check

Refs #179