### PR TITLE
Fix release latest flag values

### DIFF
--- a/.github/workflows/release-on-deploy.yml
+++ b/.github/workflows/release-on-deploy.yml
@@ -165,7 +165,7 @@ jobs:
               body,
               draft: false,
               prerelease: false,
-              make_latest: false,
+              make_latest: 'false',
               generate_release_notes: true,
             });
 

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -231,7 +231,7 @@ jobs:
               body,
               draft: false,
               prerelease: false,
-              make_latest: true,
+              make_latest: 'true',
             });
             core.setOutput('url', release.data.html_url);
 


### PR DESCRIPTION
## Summary
- use GitHub Release API string values for make_latest
- restore deployment-release publication and semantic Latest publication

## Verification
- YAML parsing for both release workflows
- git diff --check
- pre-push lint, test, and production build

Refs #179