### PR TITLE
fix: skip release polling for non-deployable commits

### DIFF
--- a/.github/workflows/portfolio-integrity.yml
+++ b/.github/workflows/portfolio-integrity.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Test deployed route checker
         run: python3 scripts/test_deployed_routes.py
 
+      - name: Test Netlify deploy-state classifier
+        run: python3 scripts/test_netlify_deploy_state.py
+
       - name: Check AI discovery artifacts
         run: node .codex/skills/ai-discovery-maintainer/scripts/check_ai_discovery.mjs "$GITHUB_WORKSPACE"
 

--- a/.github/workflows/release-on-deploy.yml
+++ b/.github/workflows/release-on-deploy.yml
@@ -43,16 +43,20 @@ jobs:
         working-directory: main
         run: npm test
 
+      - name: Test Netlify deploy-state classifier
+        run: python3 scripts/test_netlify_deploy_state.py
+
       - name: Build
         working-directory: main
         run: npm run build
 
-  release:
-    name: Create release
+  resolve_deploy:
+    name: Resolve Netlify production deploy
     runs-on: ubuntu-latest
     needs: verify
-    permissions:
-      contents: write
+    outputs:
+      deployed: ${{ steps.resolve.outputs.deployed }}
+      deploy_url: ${{ steps.resolve.outputs.deploy_url }}
 
     steps:
       - name: Check out repository
@@ -60,12 +64,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Node
-        uses: actions/setup-node@v7
-        with:
-          node-version: 22.22.3
-
-      - name: Wait for Netlify production deploy
+      - name: Resolve Netlify production deploy
+        id: resolve
         env:
           EXPECTED_COMMIT: ${{ github.sha }}
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
@@ -82,23 +82,67 @@ jobs:
             deploy_json="$(curl -fsS \
               -H "Authorization: Bearer ${NETLIFY_AUTH_TOKEN}" \
               "https://api.netlify.com/api/v1/sites/${NETLIFY_SITE_ID}/deploys?production=true&per_page=1")"
-            deploy_state="$(printf '%s' "$deploy_json" | python3 -c 'import json, sys; deploys = json.load(sys.stdin); deploy = deploys[0] if deploys else {}; print(deploy.get("state", ""))')"
-            deploy_commit="$(printf '%s' "$deploy_json" | python3 -c 'import json, sys; deploys = json.load(sys.stdin); deploy = deploys[0] if deploys else {}; print(deploy.get("commit_ref", ""))')"
-            deploy_url="$(printf '%s' "$deploy_json" | python3 -c 'import json, sys; deploys = json.load(sys.stdin); deploy = deploys[0] if deploys else {}; print(deploy.get("deploy_ssl_url") or deploy.get("ssl_url") or "")')"
-
-            if [ "$deploy_state" = "ready" ] && [ "$deploy_commit" = "$EXPECTED_COMMIT" ]; then
-              echo "Netlify production deploy is ready for ${EXPECTED_COMMIT}: ${deploy_url}"
-              break
-            fi
-
-            if [ "$attempt" = "45" ]; then
-              echo "Timed out waiting for Netlify production deploy ${EXPECTED_COMMIT}. Last state=${deploy_state}, commit=${deploy_commit}, url=${deploy_url}"
+            if ! classification="$(printf '%s' "$deploy_json" | python3 scripts/check_netlify_deploy_state.py --expected-commit "$EXPECTED_COMMIT")"; then
+              echo "::error::Could not classify the latest Netlify production deploy."
               exit 1
             fi
 
-            echo "Waiting for Netlify production deploy ${EXPECTED_COMMIT}; attempt ${attempt}/45 saw state=${deploy_state}, commit=${deploy_commit}"
-            sleep 20
+            decision="$(printf '%s' "$classification" | python3 -c 'import json, sys; print(json.load(sys.stdin)["decision"])')"
+            deploy_state="$(printf '%s' "$classification" | python3 -c 'import json, sys; print(json.load(sys.stdin)["state"])')"
+            deploy_commit="$(printf '%s' "$classification" | python3 -c 'import json, sys; print(json.load(sys.stdin)["commit_ref"])')"
+            deploy_url="$(printf '%s' "$classification" | python3 -c 'import json, sys; print(json.load(sys.stdin)["deploy_url"])')"
+
+            case "$decision" in
+              ready)
+                echo "Netlify production deploy is ready for ${EXPECTED_COMMIT}: ${deploy_url}"
+                echo "deployed=true" >> "$GITHUB_OUTPUT"
+                echo "deploy_url=${deploy_url}" >> "$GITHUB_OUTPUT"
+                exit 0
+                ;;
+              skipped)
+                echo "Netlify skipped the production deploy for ${EXPECTED_COMMIT}; no deployment release will be created."
+                echo "deployed=false" >> "$GITHUB_OUTPUT"
+                echo "deploy_url=" >> "$GITHUB_OUTPUT"
+                exit 0
+                ;;
+              failed)
+                echo "::error::Netlify production deploy ${EXPECTED_COMMIT} reached terminal state ${deploy_state}."
+                exit 1
+                ;;
+              wait)
+                if [ "$attempt" = "45" ]; then
+                  echo "::error::Timed out waiting for Netlify production deploy ${EXPECTED_COMMIT}. Last state=${deploy_state}, commit=${deploy_commit}, url=${deploy_url}"
+                  exit 1
+                fi
+
+                echo "Waiting for Netlify production deploy ${EXPECTED_COMMIT}; attempt ${attempt}/45 saw state=${deploy_state}, commit=${deploy_commit}"
+                sleep 20
+                ;;
+              *)
+                echo "::error::Deploy-state classifier returned unexpected decision ${decision}."
+                exit 1
+                ;;
+            esac
           done
+
+  release:
+    name: Create release
+    runs-on: ubuntu-latest
+    needs: resolve_deploy
+    if: needs.resolve_deploy.outputs.deployed == 'true'
+    permissions:
+      contents: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22.22.3
 
       - name: Test deployed route checker
         run: python3 scripts/test_deployed_routes.py
@@ -138,6 +182,8 @@ jobs:
 
       - name: Create GitHub release
         uses: actions/github-script@v9
+        env:
+          NETLIFY_DEPLOY_URL: ${{ needs.resolve_deploy.outputs.deploy_url }}
         with:
           script: |
             const shortSha = context.sha.slice(0, 7);
@@ -154,6 +200,7 @@ jobs:
               `- Branch: ${context.ref.replace("refs/heads/", "")}`,
               `- Workflow run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
               "- Site: https://waffy.dev",
+              `- Netlify deploy: ${process.env.NETLIFY_DEPLOY_URL}`,
             ].join("\n");
 
             await github.rest.repos.createRelease({

--- a/docs/release-versioning.md
+++ b/docs/release-versioning.md
@@ -2,8 +2,10 @@
 
 This repository keeps two independent release records:
 
-- `deploy-YYYYMMDDTHHMMSSZ-<short-sha>` releases are immutable production-deployment provenance. Every successful production merge continues to create one, and they are never retagged, deleted, or made Latest.
+- `deploy-YYYYMMDDTHHMMSSZ-<short-sha>` releases are immutable production-deployment provenance. A successful `main` commit creates one only when Netlify reports a ready production deploy for that exact commit, and they are never retagged, deleted, or made Latest.
 - `vMAJOR.MINOR.PATCH` releases are deliberately curated milestones. They point to an already-ready Netlify production commit and are marked Latest.
+
+The deployment-release workflow exits successfully without creating a GitHub release when Netlify explicitly marks the exact commit's production deploy as skipped. This covers non-deployable commits without weakening the exact-commit gate: terminal deploy failures, malformed responses, and polling timeouts still fail closed.
 
 `main/package.json` is the authoritative semantic version. `main/package-lock.json` repeats the same value in its top-level `version` and root-package `packages[""]` fields. A release request must use the package version without a `v`; the published tag receives the `v` prefix.
 

--- a/scripts/check_netlify_deploy_state.py
+++ b/scripts/check_netlify_deploy_state.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import sys
+
+
+TERMINAL_FAILURE_STATES = {"error", "rejected"}
+
+
+def _optional_string(deploy, field):
+    value = deploy.get(field)
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise ValueError(f"latest deploy field {field!r} must be a string or null")
+    if "\n" in value or "\r" in value:
+        raise ValueError(f"latest deploy field {field!r} must not contain newlines")
+    return value
+
+
+def classify_deploys(deploys, expected_commit):
+    if not isinstance(expected_commit, str) or not expected_commit:
+        raise ValueError("expected commit must be a nonempty string")
+    if not isinstance(deploys, list):
+        raise ValueError("Netlify response must be a JSON list")
+
+    if not deploys:
+        return {
+            "decision": "wait",
+            "state": "",
+            "commit_ref": "",
+            "deploy_url": "",
+        }
+
+    deploy = deploys[0]
+    if not isinstance(deploy, dict):
+        raise ValueError("latest deploy entry must be a JSON object")
+
+    state = _optional_string(deploy, "state")
+    commit_ref = _optional_string(deploy, "commit_ref")
+    deploy_ssl_url = _optional_string(deploy, "deploy_ssl_url")
+    ssl_url = _optional_string(deploy, "ssl_url")
+    deploy_url = deploy_ssl_url or ssl_url
+
+    skipped = deploy.get("skipped", False)
+    if not isinstance(skipped, bool):
+        raise ValueError("latest deploy field 'skipped' must be a boolean")
+
+    decision = "wait"
+    if commit_ref == expected_commit:
+        if skipped is True:
+            decision = "skipped"
+        elif state == "ready":
+            decision = "ready"
+        elif state in TERMINAL_FAILURE_STATES:
+            decision = "failed"
+
+    return {
+        "decision": decision,
+        "state": state,
+        "commit_ref": commit_ref,
+        "deploy_url": deploy_url,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Classify the latest Netlify production deploy for a commit."
+    )
+    parser.add_argument(
+        "--expected-commit",
+        required=True,
+        help="Exact Git commit SHA expected from the newest production deploy.",
+    )
+    args = parser.parse_args()
+
+    try:
+        deploys = json.load(sys.stdin)
+        result = classify_deploys(deploys, args.expected_commit)
+    except (json.JSONDecodeError, ValueError) as error:
+        print(f"Invalid Netlify deploy response: {error}", file=sys.stderr)
+        return 2
+
+    json.dump(result, sys.stdout, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_netlify_deploy_state.py
+++ b/scripts/test_netlify_deploy_state.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+sys.dont_write_bytecode = True
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+CHECKER_PATH = SCRIPTS_DIR / "check_netlify_deploy_state.py"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import check_netlify_deploy_state as checker  # noqa: E402
+
+
+EXPECTED_COMMIT = "a" * 40
+OTHER_COMMIT = "b" * 40
+
+
+def deploy(*, commit_ref=EXPECTED_COMMIT, state="building", skipped=False):
+    return {
+        "commit_ref": commit_ref,
+        "state": state,
+        "skipped": skipped,
+        "deploy_ssl_url": "https://example-deploy.netlify.app",
+    }
+
+
+class NetlifyDeployStateTest(unittest.TestCase):
+    def decision(self, payload):
+        return checker.classify_deploys(payload, EXPECTED_COMMIT)["decision"]
+
+    def test_exact_skipped_deploy_is_skipped(self):
+        self.assertEqual(
+            self.decision([deploy(state="error", skipped=True)]),
+            "skipped",
+        )
+
+    def test_skipped_takes_precedence_over_ready_and_error(self):
+        for state in ("ready", "error"):
+            with self.subTest(state=state):
+                self.assertEqual(
+                    self.decision([deploy(state=state, skipped=True)]),
+                    "skipped",
+                )
+
+    def test_skipped_deploy_for_other_commit_waits(self):
+        self.assertEqual(
+            self.decision(
+                [deploy(commit_ref=OTHER_COMMIT, state="error", skipped=True)]
+            ),
+            "wait",
+        )
+
+    def test_exact_ready_deploy_is_ready(self):
+        result = checker.classify_deploys(
+            [deploy(state="ready")], EXPECTED_COMMIT
+        )
+
+        self.assertEqual(result["decision"], "ready")
+        self.assertEqual(result["commit_ref"], EXPECTED_COMMIT)
+        self.assertEqual(
+            result["deploy_url"], "https://example-deploy.netlify.app"
+        )
+
+    def test_exact_terminal_failure_is_failed(self):
+        for state in ("error", "rejected"):
+            with self.subTest(state=state):
+                self.assertEqual(self.decision([deploy(state=state)]), "failed")
+
+    def test_nonterminal_and_unknown_states_wait(self):
+        for state in ("processing", "retrying", "future-state"):
+            with self.subTest(state=state):
+                self.assertEqual(self.decision([deploy(state=state)]), "wait")
+
+    def test_empty_response_waits(self):
+        self.assertEqual(self.decision([]), "wait")
+
+    def test_invalid_response_shapes_fail_closed(self):
+        invalid_payloads = ({}, ["not-an-object"], [{"skipped": "true"}])
+
+        for payload in invalid_payloads:
+            with self.subTest(payload=payload):
+                with self.assertRaises(ValueError):
+                    checker.classify_deploys(payload, EXPECTED_COMMIT)
+
+    def test_only_newest_deploy_is_considered(self):
+        payload = [
+            deploy(commit_ref=OTHER_COMMIT, state="ready"),
+            deploy(commit_ref=EXPECTED_COMMIT, state="ready"),
+        ]
+
+        self.assertEqual(self.decision(payload), "wait")
+
+    def test_cli_rejects_malformed_json_without_echoing_it(self):
+        malformed = '{"secret": "do-not-log"'
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(CHECKER_PATH),
+                "--expected-commit",
+                EXPECTED_COMMIT,
+            ],
+            input=malformed,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("Invalid Netlify deploy response", result.stderr)
+        self.assertNotIn("do-not-log", result.stderr)
+        self.assertEqual(result.stdout, "")
+
+    def test_cli_emits_structured_result(self):
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(CHECKER_PATH),
+                "--expected-commit",
+                EXPECTED_COMMIT,
+            ],
+            input=json.dumps([deploy(state="ready")]),
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(json.loads(result.stdout)["decision"], "ready")
+        self.assertEqual(result.stderr, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- classify the newest Netlify production deploy for the exact main commit, with skipped taking precedence over ready and terminal failure states
- resolve an exact skipped deploy immediately without creating a deployment release, while retaining bounded polling and fail-closed behavior for delayed, malformed, or failed deploys
- preserve deployed route, security-header, artifact, CSP, redirect, release, and advisory browser checks behind the ready-deploy gate
- add deterministic classifier coverage to both release verification and Portfolio Integrity, and document the skipped-deploy release policy

## Verification

- python3 scripts/test_netlify_deploy_state.py (11 tests)
- Ruby YAML parse for both changed workflows
- workflow job graph and permission assertions
- git diff --check
- npm run test:release (13 tests)
- npm run lint
- npm run test (44 tests)
- npm run build
- npm run audit:ci (production and full dependency audits)
- portfolio release preflight
- pre-push lint, test, and build hook

## Review notes

- contents:write remains limited to the release job; the deploy resolver inherits contents:read
- no dependencies, Netlify configuration, secret requirements, or broader workflow permissions changed
- no live deployment or production workflow was triggered; skipped-path production evidence remains a post-merge observation

Refs #184