### PR TITLE
Fix Netlify no-content deploy classification

### DIFF
--- a/docs/release-versioning.md
+++ b/docs/release-versioning.md
@@ -5,7 +5,7 @@ This repository keeps two independent release records:
 - `deploy-YYYYMMDDTHHMMSSZ-<short-sha>` releases are immutable production-deployment provenance. A successful `main` commit creates one only when Netlify reports a ready production deploy for that exact commit, and they are never retagged, deleted, or made Latest.
 - `vMAJOR.MINOR.PATCH` releases are deliberately curated milestones. They point to an already-ready Netlify production commit and are marked Latest.
 
-The deployment-release workflow exits successfully without creating a GitHub release when Netlify explicitly marks the exact commit's production deploy as skipped. This covers non-deployable commits without weakening the exact-commit gate: terminal deploy failures, malformed responses, and polling timeouts still fail closed.
+The deployment-release workflow exits successfully without creating a GitHub release when Netlify marks the exact commit's production deploy with `skipped: true` or returns the exact no-content cancellation signal. This covers non-deployable commits without weakening the exact-commit gate: other terminal deploy failures, malformed responses, and polling timeouts still fail closed.
 
 `main/package.json` is the authoritative semantic version. `main/package-lock.json` repeats the same value in its top-level `version` and root-package `packages[""]` fields. A release request must use the package version without a `v`; the published tag receives the `v` prefix.
 

--- a/scripts/check_netlify_deploy_state.py
+++ b/scripts/check_netlify_deploy_state.py
@@ -5,6 +5,10 @@ import sys
 
 
 TERMINAL_FAILURE_STATES = {"error", "rejected"}
+NO_CONTENT_CHANGE_ERROR_MESSAGE = (
+    "Failed during stage 'checking build content for changes': "
+    "Canceled build due to no content change"
+)
 
 
 def _optional_string(deploy, field):
@@ -41,14 +45,19 @@ def classify_deploys(deploys, expected_commit):
     deploy_ssl_url = _optional_string(deploy, "deploy_ssl_url")
     ssl_url = _optional_string(deploy, "ssl_url")
     deploy_url = deploy_ssl_url or ssl_url
+    error_message = _optional_string(deploy, "error_message")
 
-    skipped = deploy.get("skipped", False)
-    if not isinstance(skipped, bool):
-        raise ValueError("latest deploy field 'skipped' must be a boolean")
+    skipped = deploy.get("skipped")
+    if skipped is not None and not isinstance(skipped, bool):
+        raise ValueError(
+            "latest deploy field 'skipped' must be a boolean or null"
+        )
 
     decision = "wait"
     if commit_ref == expected_commit:
         if skipped is True:
+            decision = "skipped"
+        elif state == "error" and error_message == NO_CONTENT_CHANGE_ERROR_MESSAGE:
             decision = "skipped"
         elif state == "ready":
             decision = "ready"

--- a/scripts/test_netlify_deploy_state.py
+++ b/scripts/test_netlify_deploy_state.py
@@ -17,26 +17,49 @@ import check_netlify_deploy_state as checker  # noqa: E402
 
 EXPECTED_COMMIT = "a" * 40
 OTHER_COMMIT = "b" * 40
+MISSING = object()
 
 
-def deploy(*, commit_ref=EXPECTED_COMMIT, state="building", skipped=False):
-    return {
+def deploy(
+    *,
+    commit_ref=EXPECTED_COMMIT,
+    state="building",
+    skipped=MISSING,
+    error_message=MISSING,
+):
+    payload = {
         "commit_ref": commit_ref,
         "state": state,
-        "skipped": skipped,
         "deploy_ssl_url": "https://example-deploy.netlify.app",
     }
+    if skipped is not MISSING:
+        payload["skipped"] = skipped
+    if error_message is not MISSING:
+        payload["error_message"] = error_message
+    return payload
 
 
 class NetlifyDeployStateTest(unittest.TestCase):
     def decision(self, payload):
         return checker.classify_deploys(payload, EXPECTED_COMMIT)["decision"]
 
-    def test_exact_skipped_deploy_is_skipped(self):
+    def test_no_content_message_matches_netlify_signal(self):
         self.assertEqual(
-            self.decision([deploy(state="error", skipped=True)]),
-            "skipped",
+            checker.NO_CONTENT_CHANGE_ERROR_MESSAGE,
+            "Failed during stage 'checking build content for changes': "
+            "Canceled build due to no content change",
         )
+
+    def test_missing_false_and_null_skipped_values_allow_ready(self):
+        for skipped in (MISSING, False, None):
+            with self.subTest(skipped=skipped):
+                self.assertEqual(
+                    self.decision([deploy(state="ready", skipped=skipped)]),
+                    "ready",
+                )
+
+    def test_true_skipped_value_is_skipped(self):
+        self.assertEqual(self.decision([deploy(skipped=True)]), "skipped")
 
     def test_skipped_takes_precedence_over_ready_and_error(self):
         for state in ("ready", "error"):
@@ -46,12 +69,99 @@ class NetlifyDeployStateTest(unittest.TestCase):
                     "skipped",
                 )
 
-    def test_skipped_deploy_for_other_commit_waits(self):
+    def test_no_content_error_with_null_skipped_value_is_skipped(self):
+        result = checker.classify_deploys(
+            [
+                deploy(
+                    state="error",
+                    skipped=None,
+                    error_message=checker.NO_CONTENT_CHANGE_ERROR_MESSAGE,
+                )
+            ],
+            EXPECTED_COMMIT,
+        )
+
+        self.assertEqual(result["decision"], "skipped")
+        self.assertNotIn("error_message", result)
+
+    def test_genuine_error_with_null_skipped_value_is_failed(self):
         self.assertEqual(
             self.decision(
-                [deploy(commit_ref=OTHER_COMMIT, state="error", skipped=True)]
+                [
+                    deploy(
+                        state="error",
+                        skipped=None,
+                        error_message="Build command failed",
+                    )
+                ]
             ),
-            "wait",
+            "failed",
+        )
+
+    def test_no_content_error_message_requires_exact_match(self):
+        exact = checker.NO_CONTENT_CHANGE_ERROR_MESSAGE
+        altered_messages = (
+            exact.lower(),
+            f"{exact} ",
+            exact.replace("no content change", "no changed content"),
+        )
+
+        for error_message in altered_messages:
+            with self.subTest(error_message=error_message):
+                self.assertEqual(
+                    self.decision(
+                        [
+                            deploy(
+                                state="error",
+                                skipped=None,
+                                error_message=error_message,
+                            )
+                        ]
+                    ),
+                    "failed",
+                )
+
+    def test_rejected_is_failed_even_with_no_content_message(self):
+        self.assertEqual(
+            self.decision(
+                [
+                    deploy(
+                        state="rejected",
+                        skipped=None,
+                        error_message=checker.NO_CONTENT_CHANGE_ERROR_MESSAGE,
+                    )
+                ]
+            ),
+            "failed",
+        )
+
+    def test_skipped_and_no_content_signals_for_other_commit_wait(self):
+        cases = (
+            deploy(commit_ref=OTHER_COMMIT, state="error", skipped=True),
+            deploy(
+                commit_ref=OTHER_COMMIT,
+                state="error",
+                skipped=None,
+                error_message=checker.NO_CONTENT_CHANGE_ERROR_MESSAGE,
+            ),
+        )
+
+        for payload in cases:
+            with self.subTest(payload=payload):
+                self.assertEqual(self.decision([payload]), "wait")
+
+    def test_no_content_message_only_overrides_the_error_state(self):
+        self.assertEqual(
+            self.decision(
+                [
+                    deploy(
+                        state="ready",
+                        skipped=None,
+                        error_message=checker.NO_CONTENT_CHANGE_ERROR_MESSAGE,
+                    )
+                ]
+            ),
+            "ready",
         )
 
     def test_exact_ready_deploy_is_ready(self):
@@ -65,11 +175,6 @@ class NetlifyDeployStateTest(unittest.TestCase):
             result["deploy_url"], "https://example-deploy.netlify.app"
         )
 
-    def test_exact_terminal_failure_is_failed(self):
-        for state in ("error", "rejected"):
-            with self.subTest(state=state):
-                self.assertEqual(self.decision([deploy(state=state)]), "failed")
-
     def test_nonterminal_and_unknown_states_wait(self):
         for state in ("processing", "retrying", "future-state"):
             with self.subTest(state=state):
@@ -79,12 +184,44 @@ class NetlifyDeployStateTest(unittest.TestCase):
         self.assertEqual(self.decision([]), "wait")
 
     def test_invalid_response_shapes_fail_closed(self):
-        invalid_payloads = ({}, ["not-an-object"], [{"skipped": "true"}])
+        invalid_payloads = ({}, ["not-an-object"])
 
         for payload in invalid_payloads:
             with self.subTest(payload=payload):
                 with self.assertRaises(ValueError):
                     checker.classify_deploys(payload, EXPECTED_COMMIT)
+
+    def test_invalid_skipped_types_fail_closed(self):
+        for skipped in ("true", 1, 0.0, [], {}):
+            with self.subTest(skipped=skipped):
+                with self.assertRaisesRegex(ValueError, "'skipped'"):
+                    checker.classify_deploys(
+                        [deploy(state="ready", skipped=skipped)], EXPECTED_COMMIT
+                    )
+
+    def test_invalid_error_message_types_and_newlines_fail_closed(self):
+        invalid_messages = (
+            True,
+            1,
+            [],
+            {},
+            "line one\nline two",
+            "line one\rline two",
+        )
+
+        for error_message in invalid_messages:
+            with self.subTest(error_message=error_message):
+                with self.assertRaisesRegex(ValueError, "'error_message'"):
+                    checker.classify_deploys(
+                        [
+                            deploy(
+                                state="error",
+                                skipped=None,
+                                error_message=error_message,
+                            )
+                        ],
+                        EXPECTED_COMMIT,
+                    )
 
     def test_only_newest_deploy_is_considered(self):
         payload = [


### PR DESCRIPTION
## Summary

- Treat a missing or null Netlify skipped field as an allowed API shape while still rejecting malformed types.
- Classify only the exact expected-commit, error-state, no-content cancellation signal as skipped; genuine terminal failures still fail closed.
- Add regression coverage for successful deploys, no-content cancellations, message drift, wrong commits, malformed responses, and output secrecy, then align the release documentation.

## Verification

- python3 scripts/test_netlify_deploy_state.py (19 passed)
- npm run lint
- npm run test (44 passed)
- npm run test:release (13 passed)
- npm run build
- portfolio release preflight
- portfolio change-impact check
- read-only live Netlify classifier checks: b930424eec1aa4bb3416d02ba180a09480d60eca -> skipped; 78d13fcc6a40d08c98cf25999c8f9c5cd37398cf -> ready

## Safety boundary

- No workflow graph, permissions, secrets, polling cadence, tags, releases, or deployments are changed.
- The provider message comparison is exact so unrecognized terminal failures remain failures.

Refs #184