### PR TITLE
Add pre-merge browser quality gate

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -45,3 +45,43 @@ jobs:
       - name: Build
         working-directory: main
         run: npm run build
+
+  premerge-browser-smoke:
+    name: Pre-merge browser smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22.22.3
+          cache: npm
+          cache-dependency-path: main/package-lock.json
+
+      - name: Install dependencies
+        working-directory: main
+        run: npm ci
+
+      - name: Install Chromium
+        working-directory: main
+        run: npx playwright install --with-deps chromium
+
+      - name: Run local pre-merge browser smoke tests
+        run: npm run test:e2e:premerge
+
+      - name: Upload browser failure evidence
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: premerge-browser-smoke-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            main/playwright-report/
+            main/test-results/
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -4,13 +4,6 @@ name: npm audit
   pull_request:
     branches:
       - main
-    paths:
-      - ".npmrc"
-      - "main/.npmrc"
-      - "main/package.json"
-      - "main/package-lock.json"
-      - "main/scripts/check-npm-audit.mjs"
-      - ".github/workflows/npm-audit.yml"
   schedule:
     - cron: "18 14 * * 1"
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Run these commands from the repository root:
 | `npm run lint` | Run ESLint |
 | `npm test` | Run the Vitest test suite |
 | `npm run test:release` | Run semantic-release version validator tests |
+| `npm run test:e2e:premerge` | Build and smoke-test a local production-equivalent Vite preview |
 | `npm run test:e2e:production` | Run telemetry-safe Chromium smoke tests against production |
 | `npm run build` | Create the production build |
 | `npm run preview` | Preview the production build locally |
@@ -206,12 +207,15 @@ CSP, and byte-for-byte public-artifact contracts against `https://waffy.dev/`.
 Run it manually after intentional production-policy or public-artifact changes
 have deployed.
 
-`npm run test:e2e:production` opens the live production site in fresh desktop
-and mobile Chromium contexts. The suite blocks GA4, Google Tag Manager,
-DoubleClick, and Formspree requests, and it never submits the contact form. It
-therefore validates hydration, navigation, responsive overflow, lazy chunks,
-resume rendering, and browser errors without validating analytics delivery or
-form submission.
+`npm run test:e2e:premerge` builds the app with a synthetic, non-secret
+Formspree key and opens only a local Vite preview. `npm run
+test:e2e:production` defaults to the live production site; callers can set
+`PLAYWRIGHT_PRODUCTION_BASE_URL` to an explicit deployed target. Both commands
+use fresh desktop and mobile Chromium contexts. The suite blocks GA4, Google
+Tag Manager, DoubleClick, and Formspree requests, and it never submits the
+contact form. It therefore validates hydration, navigation, responsive
+overflow, lazy chunks, resume rendering, and browser errors without validating
+analytics delivery or form submission.
 
 ## Deployment
 

--- a/docs/main-branch-governance.md
+++ b/docs/main-branch-governance.md
@@ -1,0 +1,129 @@
+# Main Branch Governance
+
+This document defines the proposed protection contract for the default branch.
+It does not claim that GitHub settings have been applied. Creating or changing
+the ruleset, exercising a canary pull request, merging, deploying, releasing,
+and closing Issue #164 each require their own direct authorization.
+
+## Dated Baseline
+
+On 2026-08-23, authenticated read-only API requests returned no repository
+rulesets and reported that `main` had no branch-protection rule. Issue #164
+tracks applying and proving the design below. Because provider state can drift,
+operators must refresh this evidence before any settings change or closure.
+
+## Proposed Active Ruleset
+
+Create one repository branch ruleset named `Protect main quality gates` with
+`enforcement: active`, targeting only the default branch (`~DEFAULT_BRANCH`).
+Configure these rules:
+
+- Require changes through a pull request, with zero required approving reviews.
+- Require all review conversations to be resolved before merge.
+- Require branches to be up to date before merging.
+- Require these four GitHub Actions status checks by exact job name:
+
+  1. `Verify app` from `.github/workflows/dev-ci.yml`
+  2. `Pre-merge browser smoke` from `.github/workflows/dev-ci.yml`
+  3. `Validate portfolio surfaces` from
+     `.github/workflows/portfolio-integrity.yml`
+  4. `Audit npm dependencies` from `.github/workflows/npm-audit.yml`
+
+- Require native code-scanning results from `CodeQL` with security alerts set
+  to `high_or_higher` and non-security alerts set to `errors`.
+- Block branch deletion and block force pushes.
+
+Do not add a required Netlify Deploy Preview, Netlify deployment, production
+browser, or other third-party status check. The production browser smoke in
+`.github/workflows/release-on-deploy.yml` remains an additional advisory lane
+after the production deployment and release are created.
+
+GitHub rulesets identify ordinary workflow checks by job name, not by workflow
+name. The workflow paths above disambiguate ownership for operators and
+reviewers; the backticked job names are the exact required-check contexts.
+
+## Emergency Bypass Policy
+
+Grant bypass only to the repository-admin role, with bypass mode set to
+`pull_request`. This keeps an auditable pull-request trail while permitting the
+solo owner to handle a genuine repository emergency. Do not grant an
+always-allow bypass, direct-push bypass, GitHub App bypass, Dependabot bypass,
+or other bot/integration bypass.
+
+Use the emergency bypass only when waiting for the normal gate would materially
+worsen an active incident or prevent repair of the gate itself. Record the
+reason in the pull request. Routine maintenance, dependency updates, and CI
+flake are not bypass reasons.
+
+## No-Deadlock Design
+
+Every proposed required workflow reports on every pull request to `main`:
+
+- `dev-ci.yml` has no path filter and its two candidate required jobs use only
+  repository contents and the local Vite preview.
+- `portfolio-integrity.yml` has no path filter.
+- `npm-audit.yml` has no pull-request path filter.
+- `codeql.yml` has no pull-request path filter.
+
+The pre-merge browser job and npm audit job use read-only repository access,
+do not require secrets, and do not depend on Netlify. These properties let them
+run for documentation-only and Dependabot pull requests without a privileged
+bot bypass. `release-on-deploy.yml` runs only after a push to `main`, so it must
+not be configured as a pre-merge requirement.
+
+## Bootstrap And Proof Sequence
+
+Perform these phases in order, stopping for the named human gate between them:
+
+1. Merge the reviewed repository PR only after a separate `MERGE_PR` grant that
+   names its exact reviewed SHA and acknowledges the automatic Netlify deploy,
+   verification, deploy tag, GitHub Release, and advisory production-browser
+   consequences.
+2. Confirm a representative pull request has reported all four exact job names
+   and CodeQL has produced results. Do not configure a context that has not
+   appeared in GitHub's authenticated check-run readback.
+3. With a separate settings-mutation grant, create the ruleset exactly as
+   proposed. Immediately read back the ruleset by authenticated API and verify
+   its target, active enforcement, bypass actors/modes, pull-request settings,
+   strict required checks, CodeQL thresholds, deletion rule, and force-push
+   rule. Also inspect all rules applying to `main` for unexpected layering.
+4. With separate authorization, open a non-production canary pull request.
+   Introduce an intentionally failing browser assertion, prove that
+   `Pre-merge browser smoke` fails and merge is blocked, then restore the
+   assertion, prove all requirements pass, and leave the canary unmerged unless
+   merge is separately authorized. The canary must use localhost, intercept
+   GA4/GTM and Formspree, submit no form, and create no production traffic.
+5. Exercise a documentation-only change and a representative Dependabot pull
+   request, or use equivalent authenticated check-run evidence, to confirm all
+   required contexts report instead of remaining pending.
+6. Record dated authenticated settings, check-run, canary, and release evidence
+   in Issue #164. Closing the issue or changing its project state requires a
+   separate `CLOSE_WORK_ITEM` grant after every acceptance criterion is proven.
+
+If any exact context is absent, CodeQL is not configured for the target, an
+unexpected rule layers onto `main`, or the canary cannot prove both blocked and
+restored states, stop and repair the repository workflow or revise the proposed
+settings through a new reviewed change before activating or retaining the gate.
+
+## Evidence Checklist
+
+Retain the following immutable or dated evidence:
+
+- the reviewed PR URL, base-tip SHA, merge-base SHA, and exact head SHA;
+- successful check-run IDs and conclusions for the four named jobs and CodeQL;
+- the authenticated ruleset JSON and the effective rules applying to `main`;
+- canary PR URL and failing/restored head SHAs with mergeability readback;
+- documentation-only and Dependabot reporting evidence;
+- the separately authorized merge/release workflow and exact deployed commit,
+  if a merge occurs; and
+- residual gaps and the explicit closure authorization, if Issue #164 closes.
+
+Local lint, unit, build, audit, and Playwright results prove repository behavior
+only. They do not prove GitHub ruleset enforcement, hosted-runner behavior,
+Netlify deployment, production behavior, or acceptance-criteria closure.
+
+## GitHub References
+
+- [Available rules for rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets)
+- [Rulesets REST API](https://docs.github.com/en/rest/repos/rules)
+- [Code scanning merge protection](https://docs.github.com/en/code-security/how-tos/find-and-fix-code-vulnerabilities/manage-your-configuration/set-merge-protection)

--- a/docs/main-branch-governance.md
+++ b/docs/main-branch-governance.md
@@ -9,8 +9,11 @@ and closing Issue #164 each require their own direct authorization.
 
 On 2026-08-23, authenticated read-only API requests returned no repository
 rulesets and reported that `main` had no branch-protection rule. Issue #164
-tracks applying and proving the design below. Because provider state can drift,
-operators must refresh this evidence before any settings change or closure.
+tracks applying and proving the design below. Authenticated check-run readback
+also showed that all four proposed required checks came from the GitHub Actions
+app (`github-actions`), with app/integration ID `15368`. Because provider state
+can drift, operators must refresh this evidence before any settings change or
+closure.
 
 ## Proposed Active Ruleset
 
@@ -23,11 +26,15 @@ Configure these rules:
 - Require branches to be up to date before merging.
 - Require these four GitHub Actions status checks by exact job name:
 
-  1. `Verify app` from `.github/workflows/dev-ci.yml`
-  2. `Pre-merge browser smoke` from `.github/workflows/dev-ci.yml`
+  1. `Verify app` from `.github/workflows/dev-ci.yml`, source
+     `github-actions`, `integration_id: 15368`
+  2. `Pre-merge browser smoke` from `.github/workflows/dev-ci.yml`, source
+     `github-actions`, `integration_id: 15368`
   3. `Validate portfolio surfaces` from
-     `.github/workflows/portfolio-integrity.yml`
-  4. `Audit npm dependencies` from `.github/workflows/npm-audit.yml`
+     `.github/workflows/portfolio-integrity.yml`, source `github-actions`,
+     `integration_id: 15368`
+  4. `Audit npm dependencies` from `.github/workflows/npm-audit.yml`, source
+     `github-actions`, `integration_id: 15368`
 
 - Require native code-scanning results from `CodeQL` with security alerts set
   to `high_or_higher` and non-security alerts set to `errors`.
@@ -38,9 +45,13 @@ browser, or other third-party status check. The production browser smoke in
 `.github/workflows/release-on-deploy.yml` remains an additional advisory lane
 after the production deployment and release are created.
 
-GitHub rulesets identify ordinary workflow checks by job name, not by workflow
-name. The workflow paths above disambiguate ownership for operators and
-reviewers; the backticked job names are the exact required-check contexts.
+Configure each required status check with both its exact context and the
+refreshed GitHub Actions integration ID. Job names and workflow paths alone do
+not pin the source app: the workflow paths above disambiguate ownership for
+operators and reviewers, while `integration_id` prevents another integration
+from satisfying a same-named context. The IDs above record the 2026-08-23
+readback; stop and revise the reviewed proposal if authenticated readback shows
+that the provider identity has drifted before mutation.
 
 ## Emergency Bypass Policy
 
@@ -79,14 +90,17 @@ Perform these phases in order, stopping for the named human gate between them:
    names its exact reviewed SHA and acknowledges the automatic Netlify deploy,
    verification, deploy tag, GitHub Release, and advisory production-browser
    consequences.
-2. Confirm a representative pull request has reported all four exact job names
-   and CodeQL has produced results. Do not configure a context that has not
-   appeared in GitHub's authenticated check-run readback.
+2. Confirm a representative pull request has reported all four exact job names,
+   verify each check run's app slug is `github-actions`, refresh its
+   app/integration ID, and confirm CodeQL has produced results. Do not configure
+   a context or integration ID that has not appeared together in GitHub's
+   authenticated check-run readback.
 3. With a separate settings-mutation grant, create the ruleset exactly as
    proposed. Immediately read back the ruleset by authenticated API and verify
    its target, active enforcement, bypass actors/modes, pull-request settings,
-   strict required checks, CodeQL thresholds, deletion rule, and force-push
-   rule. Also inspect all rules applying to `main` for unexpected layering.
+   strict required checks and their integration IDs, CodeQL thresholds,
+   deletion rule, and force-push rule. Also inspect all rules applying to
+   `main` for unexpected layering.
 4. With separate authorization, open a non-production canary pull request.
    Introduce an intentionally failing browser assertion, prove that
    `Pre-merge browser smoke` fails and merge is blocked, then restore the
@@ -110,7 +124,8 @@ settings through a new reviewed change before activating or retaining the gate.
 Retain the following immutable or dated evidence:
 
 - the reviewed PR URL, base-tip SHA, merge-base SHA, and exact head SHA;
-- successful check-run IDs and conclusions for the four named jobs and CodeQL;
+- successful check-run IDs, conclusions, app slugs, and app/integration IDs for
+  the four named jobs, plus CodeQL results;
 - the authenticated ruleset JSON and the effective rules applying to `main`;
 - canary PR URL and failing/restored head SHAs with mergeability readback;
 - documentation-only and Dependabot reporting evidence;

--- a/main/e2e/production-smoke.spec.js
+++ b/main/e2e/production-smoke.spec.js
@@ -1,11 +1,23 @@
 const { test: base, expect } = require("@playwright/test")
 
 
-const routeExpectations = [
+const canonicalRouteExpectations = [
   { path: "/", heading: "Waffy Ahmed" },
   { path: "/projects/", heading: "Practical builds for real workflows" },
   { path: "/experience/", heading: "Work Experience" },
   { path: "/case-studies/", heading: "Selected engineering case studies" },
+  {
+    path: "/case-studies/kubernetes-autoscaling/",
+    heading: "Kubernetes Autoscaling for Transaction-Critical Services",
+  },
+  {
+    path: "/case-studies/legacy-deployment-recovery/",
+    heading: "Legacy Deployment Recovery and Credential Rotation",
+  },
+  {
+    path: "/case-studies/cdc-data-reconciliation/",
+    heading: "CDC Data Reconciliation Platform",
+  },
   { path: "/resume/", heading: "Resume" },
   { path: "/contact/", heading: "Let's connect" },
 ]
@@ -127,7 +139,29 @@ function monitorPage(page, baseURL) {
   }
 }
 
-for (const route of routeExpectations) {
+async function expectHydratedRoute(page, route) {
+  await expect(
+    page.getByRole("heading", { level: 1, name: route.heading })
+  ).toBeVisible()
+  await expect(
+    page.locator("[data-route-ready]")
+  ).toHaveAttribute("data-route-ready", route.path)
+  await expect(
+    page.getByRole("navigation", { name: "Primary navigation" })
+  ).toBeVisible()
+}
+
+async function expectNoHorizontalOverflow(page) {
+  const documentWidth = await page.evaluate(() => ({
+    clientWidth: globalThis.document.documentElement.clientWidth,
+    scrollWidth: globalThis.document.documentElement.scrollWidth,
+  }))
+  expect(documentWidth.scrollWidth).toBeLessThanOrEqual(
+    documentWidth.clientWidth + 1
+  )
+}
+
+for (const route of canonicalRouteExpectations) {
   test(`${route.path} hydrates without horizontal overflow`, async ({
     page,
     baseURL,
@@ -135,24 +169,38 @@ for (const route of routeExpectations) {
     const monitor = monitorPage(page, baseURL)
 
     await page.goto(route.path, { waitUntil: "domcontentloaded" })
-    await expect(
-      page.getByRole("heading", { level: 1, name: route.heading })
-    ).toBeVisible()
-    await expect(
-      page.getByRole("navigation", { name: "Primary navigation" })
-    ).toBeVisible()
+    await expectHydratedRoute(page, route)
     await page.waitForLoadState("load")
 
-    const documentWidth = await page.evaluate(() => ({
-      clientWidth: globalThis.document.documentElement.clientWidth,
-      scrollWidth: globalThis.document.documentElement.scrollWidth,
-    }))
-    expect(documentWidth.scrollWidth).toBeLessThanOrEqual(
-      documentWidth.clientWidth + 1
-    )
+    await expectNoHorizontalOverflow(page)
     monitor.assertClean()
   })
 }
+
+test("unknown route renders the hydrated 404 and returns home", async ({
+  page,
+  baseURL,
+}) => {
+  const monitor = monitorPage(page, baseURL)
+
+  await page.goto("/not-a-real-route/", { waitUntil: "domcontentloaded" })
+  await expectHydratedRoute(page, {
+    path: "/not-a-real-route/",
+    heading: "Page not found",
+  })
+  await expect(page.locator('meta[name="robots"]')).toHaveAttribute(
+    "content",
+    "noindex, nofollow"
+  )
+  await expectNoHorizontalOverflow(page)
+
+  await page.getByRole("link", { name: "Go home" }).click()
+  await expect(page).toHaveURL(/\/$/)
+  await expect(
+    page.getByRole("heading", { level: 1, name: "Waffy Ahmed" })
+  ).toBeVisible()
+  monitor.assertClean()
+})
 
 test("client navigation loads a lazy route and restores Home from history", async ({
   page,

--- a/main/e2e/production-smoke.spec.js
+++ b/main/e2e/production-smoke.spec.js
@@ -1,5 +1,6 @@
 const { test: base, expect } = require("@playwright/test")
 
+const telemetryGuardMarker = "__playwrightTelemetryGuardActive"
 
 const canonicalRouteExpectations = [
   { path: "/", heading: "Waffy Ahmed" },
@@ -50,45 +51,49 @@ function isExpectedAnalyticsCspError(message) {
 }
 
 const test = base.extend({
-  externalRequests: async ({ context }, use) => {
-    const externalRequests = {
-      analytics: [],
-      formspree: [],
-    }
-
-    await context.addInitScript(() => {
-      globalThis.dataLayer = []
-      globalThis.gtag = () => undefined
-    })
-
-    await context.route("**/*", async (route) => {
-      const request = route.request()
-      const { hostname } = new URL(request.url())
-
-      if (isAnalyticsHost(hostname)) {
-        externalRequests.analytics.push(request.url())
-        await route.fulfill({
-          status: 200,
-          contentType:
-            request.resourceType() === "script"
-              ? "application/javascript"
-              : "text/plain",
-          body: "",
-        })
-        return
+  externalRequests: [
+    async ({ context }, use) => {
+      const externalRequests = {
+        analytics: [],
+        formspree: [],
       }
 
-      if (isFormspreeHost(hostname)) {
-        externalRequests.formspree.push(request.url())
-        await route.abort("blockedbyclient")
-        return
-      }
+      await context.addInitScript((guardMarker) => {
+        globalThis[guardMarker] = true
+        globalThis.dataLayer = []
+        globalThis.gtag = () => undefined
+      }, telemetryGuardMarker)
 
-      await route.continue()
-    })
+      await context.route("**/*", async (route) => {
+        const request = route.request()
+        const { hostname } = new URL(request.url())
 
-    await use(externalRequests)
-  },
+        if (isAnalyticsHost(hostname)) {
+          externalRequests.analytics.push(request.url())
+          await route.fulfill({
+            status: 200,
+            contentType:
+              request.resourceType() === "script"
+                ? "application/javascript"
+                : "text/plain",
+            body: "",
+          })
+          return
+        }
+
+        if (isFormspreeHost(hostname)) {
+          externalRequests.formspree.push(request.url())
+          await route.abort("blockedbyclient")
+          return
+        }
+
+        await route.continue()
+      })
+
+      await use(externalRequests)
+    },
+    { auto: true },
+  ],
 })
 
 function monitorPage(page, baseURL) {
@@ -140,6 +145,13 @@ function monitorPage(page, baseURL) {
 }
 
 async function expectHydratedRoute(page, route) {
+  expect(
+    await page.evaluate(
+      (guardMarker) => globalThis[guardMarker] === true,
+      telemetryGuardMarker
+    ),
+    "automatic telemetry interception fixture should initialize before app code"
+  ).toBe(true)
   await expect(
     page.getByRole("heading", { level: 1, name: route.heading })
   ).toBeVisible()

--- a/main/package.json
+++ b/main/package.json
@@ -23,7 +23,7 @@
     "test": "vitest run --exclude=e2e/**",
     "test:release": "vitest run scripts/release-version.test.mjs",
     "pretest:e2e:premerge": "VITE_FORMSPREE_KEY=synthetic-premerge-test-key npm run build",
-    "test:e2e:premerge": "playwright test --config=playwright.production.config.js",
+    "test:e2e:premerge": "PLAYWRIGHT_LOCAL_PREVIEW=1 playwright test --config=playwright.production.config.js",
     "test:e2e:production": "playwright test --config=playwright.production.config.js",
     "performance:baseline": "node scripts/measure-route-performance.mjs --build --serve",
     "test:performance:baseline": "node --test scripts/measure-route-performance.node-test.mjs",

--- a/main/package.json
+++ b/main/package.json
@@ -22,7 +22,7 @@
     "preview": "vite preview",
     "test": "vitest run --exclude=e2e/**",
     "test:release": "vitest run scripts/release-version.test.mjs",
-    "pretest:e2e:premerge": "npm run build",
+    "pretest:e2e:premerge": "VITE_FORMSPREE_KEY=synthetic-premerge-test-key npm run build",
     "test:e2e:premerge": "playwright test --config=playwright.production.config.js",
     "test:e2e:production": "playwright test --config=playwright.production.config.js",
     "performance:baseline": "node scripts/measure-route-performance.mjs --build --serve",

--- a/main/package.json
+++ b/main/package.json
@@ -22,6 +22,8 @@
     "preview": "vite preview",
     "test": "vitest run --exclude=e2e/**",
     "test:release": "vitest run scripts/release-version.test.mjs",
+    "pretest:e2e:premerge": "npm run build",
+    "test:e2e:premerge": "playwright test --config=playwright.production.config.js",
     "test:e2e:production": "playwright test --config=playwright.production.config.js",
     "performance:baseline": "node scripts/measure-route-performance.mjs --build --serve",
     "test:performance:baseline": "node --test scripts/measure-route-performance.node-test.mjs",

--- a/main/playwright.production.config.js
+++ b/main/playwright.production.config.js
@@ -1,7 +1,8 @@
 const { defineConfig } = require("@playwright/test")
 
-const baseURL =
-  process.env.PLAYWRIGHT_PRODUCTION_BASE_URL || "https://waffy.dev"
+const productionBaseURL =
+  process.env.PLAYWRIGHT_PRODUCTION_BASE_URL?.trim()
+const baseURL = productionBaseURL || "http://127.0.0.1:4173"
 
 module.exports = defineConfig({
   testDir: "./e2e",
@@ -18,6 +19,15 @@ module.exports = defineConfig({
     ["line"],
     ["html", { open: "never", outputFolder: "playwright-report" }],
   ],
+  webServer: productionBaseURL
+    ? undefined
+    : {
+        command:
+          "npm run preview -- --host 127.0.0.1 --port 4173 --strictPort",
+        url: baseURL,
+        reuseExistingServer: false,
+        timeout: 120_000,
+      },
   use: {
     baseURL,
     browserName: "chromium",

--- a/main/playwright.production.config.js
+++ b/main/playwright.production.config.js
@@ -1,8 +1,12 @@
 const { defineConfig } = require("@playwright/test")
 
+const localPreviewBaseURL = "http://127.0.0.1:4173"
+const useLocalPreview = process.env.PLAYWRIGHT_LOCAL_PREVIEW === "1"
 const productionBaseURL =
   process.env.PLAYWRIGHT_PRODUCTION_BASE_URL?.trim()
-const baseURL = productionBaseURL || "http://127.0.0.1:4173"
+const baseURL = useLocalPreview
+  ? localPreviewBaseURL
+  : productionBaseURL || "https://waffy.dev"
 
 module.exports = defineConfig({
   testDir: "./e2e",
@@ -19,15 +23,15 @@ module.exports = defineConfig({
     ["line"],
     ["html", { open: "never", outputFolder: "playwright-report" }],
   ],
-  webServer: productionBaseURL
-    ? undefined
-    : {
+  webServer: useLocalPreview
+    ? {
         command:
           "npm run preview -- --host 127.0.0.1 --port 4173 --strictPort",
-        url: baseURL,
+        url: localPreviewBaseURL,
         reuseExistingServer: false,
         timeout: 120_000,
-      },
+      }
+    : undefined,
   use: {
     baseURL,
     browserName: "chromium",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "npm --prefix main run lint --",
     "test": "npm --prefix main run test --",
     "test:release": "npm --prefix main run test:release --",
+    "test:e2e:premerge": "npm --prefix main run test:e2e:premerge --",
     "test:e2e:production": "npm --prefix main run test:e2e:production --",
     "performance:baseline": "npm --prefix main run performance:baseline --",
     "test:performance:baseline": "npm --prefix main run test:performance:baseline --",


### PR DESCRIPTION
## Summary
- add an unconditional `Pre-merge browser smoke` pull-request job using a local Vite preview with failure artifacts
- make npm audit report on every pull request and expand telemetry-safe Playwright coverage across all canonical app routes, case studies, hydrated 404 behavior, navigation, errors, first-party failures, and desktop/mobile overflow
- document the proposed active main-branch ruleset, exact checks, CodeQL thresholds, PR-only admin bypass, no-deadlock bootstrap, canary/readback evidence, and downstream gates

## Verification
- `node .codex/skills/portfolio-change-impact/scripts/check_change_impact.mjs --source staged --check`
- `npm run generate:public -- --check`
- `node .codex/skills/portfolio-performance-auditor/scripts/check_frontend_performance.mjs /Users/waffyahmed/Downloads/personalWebsite`
- `npm --prefix main run audit:ci`
- `bash .codex/skills/portfolio-release-qa/scripts/portfolio_preflight.sh /Users/waffyahmed/Downloads/personalWebsite`
- `npm run test:e2e:premerge` (26 passed; localhost only; GA4/GTM and Formspree intercepted)
- YAML parse, production-override config assertion, and `git diff --check`

## Notes
- No GitHub ruleset/settings, canary PR, production browser, merge, deploy, release, issue, or project state was mutated.
- Ruleset enforcement and hosted-runner behavior remain downstream evidence gates.

Refs #164
