### PR TITLE
[CANARY] Validate main quality gates - do not merge

### DIFF
--- a/docs/main-quality-gates-canary.md
+++ b/docs/main-quality-gates-canary.md
@@ -5,4 +5,3 @@ This temporary documentation-only marker exists solely to validate the active
 
 Do not merge this canary pull request. It must be closed and its branch deleted
 after Issue #164 validation is complete.
-

--- a/docs/main-quality-gates-canary.md
+++ b/docs/main-quality-gates-canary.md
@@ -1,0 +1,8 @@
+# Main Quality Gates Canary
+
+This temporary documentation-only marker exists solely to validate the active
+`Protect main quality gates` ruleset through an unmerged pull request.
+
+Do not merge this canary pull request. It must be closed and its branch deleted
+after Issue #164 validation is complete.
+

--- a/main/e2e/production-smoke.spec.js
+++ b/main/e2e/production-smoke.spec.js
@@ -118,13 +118,6 @@ const test = base.extend({
   ],
 })
 
-test("ruleset canary intentionally fails pre-merge browser smoke", async () => {
-  expect(
-    false,
-    "INTENTIONAL CANARY FAILURE: restore this test before review"
-  ).toBe(true)
-})
-
 function monitorPage(page, baseURL) {
   const siteOrigin = new URL(baseURL).origin
   const pageErrors = []

--- a/main/e2e/production-smoke.spec.js
+++ b/main/e2e/production-smoke.spec.js
@@ -118,6 +118,13 @@ const test = base.extend({
   ],
 })
 
+test("ruleset canary intentionally fails pre-merge browser smoke", async () => {
+  expect(
+    false,
+    "INTENTIONAL CANARY FAILURE: restore this test before review"
+  ).toBe(true)
+})
+
 function monitorPage(page, baseURL) {
   const siteOrigin = new URL(baseURL).origin
   const pageErrors = []


### PR DESCRIPTION
## Summary
- Exercise the active `Protect main quality gates` ruleset with an intentionally failing pre-merge browser assertion.
- Restore the browser test byte-for-byte in a follow-up commit so the final diff is documentation-only.

## Verification
- First head intentionally fails `Pre-merge browser smoke`; authenticated blocked-merge evidence will be captured before restoration.
- Final head must pass all required GitHub Actions checks and native CodeQL before independent review.
- Local pre-push lint, unit tests, and production build passed.

## Notes
- **CANARY: DO NOT MERGE.** This pull request must remain unmerged and be closed after Issue #164 validation.
- Browser execution is localhost-only through the existing pre-merge workflow. GA4, GTM, DoubleClick, and Formspree requests are intercepted; no form is submitted.
- No production browser, deployment, release, or production workflow is authorized or expected.

Refs #164
