### PR TITLE
Bump release version to 0.2.0

### DIFF
--- a/main/package-lock.json
+++ b/main/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "personal-website",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "personal-website",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@formspree/react": "^3.0.0",
         "react": "^19.2.7",

--- a/main/package.json
+++ b/main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "personal-website",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "engines": {
     "node": ">=22.22.2"


### PR DESCRIPTION
## Summary
- Set the authoritative semantic release version to 0.2.0.
- Keep main/package.json and both root version fields in main/package-lock.json synchronized.
- Preserve all dependency resolutions and the historical v0.1.0 baseline documentation.

## Verification
- node main/scripts/release-version.mjs 0.2.0
- npm run test:release (13 tests passed)
- worktree and staged portfolio change-impact checks
- git diff --check and exact committed-diff inspection
- portfolio release preflight: lint, 47 unit tests, production build
- enforced pre-push hook: lint, 47 unit tests, production build

## Notes
- This PR does not publish the semantic release.
- If separately authorized and merged, the push to main automatically verifies the app, resolves the exact Netlify production deploy, validates production routes, headers, artifacts, CSP and redirects, creates an immutable deploy provenance release, and runs advisory browser smoke.
- Publishing v0.2.0 remains a separate workflow action against the exact ready production merge SHA.