### PR TITLE
Fix route scroll and focus handling

### DIFF
--- a/main/e2e/production-smoke.spec.js
+++ b/main/e2e/production-smoke.spec.js
@@ -200,6 +200,13 @@ async function expectNoHorizontalOverflow(page) {
   )
 }
 
+const getViewportScrollY = (page) => page.evaluate(() => globalThis.scrollY)
+
+const setViewportScrollY = (page, scrollY) =>
+  page.evaluate((top) => {
+    globalThis.scrollTo({ top, left: 0, behavior: "instant" })
+  }, scrollY)
+
 for (const route of canonicalRouteExpectations) {
   test(`${route.path} hydrates without horizontal overflow`, async ({
     page,
@@ -253,7 +260,7 @@ test("unknown route renders the target-aware 404 and returns home", async ({
   monitor.assertClean()
 })
 
-test("client navigation loads a lazy route and restores Home from history", async ({
+test("client navigation resets forward scroll and preserves history scroll restoration", async ({
   page,
   baseURL,
 }) => {
@@ -277,12 +284,20 @@ test("client navigation loads a lazy route and restores Home from history", asyn
   await expect(
     page.getByRole("heading", { level: 1, name: "Waffy Ahmed" })
   ).toBeVisible()
+  await setViewportScrollY(page, 600)
+  await expect
+    .poll(() => getViewportScrollY(page), {
+      message: "Home route should be scrollable for history restoration",
+    })
+    .toBeGreaterThan(0)
+  const sourceScrollY = await getViewportScrollY(page)
   lazyScriptRequests.length = 0
 
-  await page
+  const projectsLink = page
     .getByRole("navigation", { name: "Primary navigation" })
     .getByRole("link", { name: "Projects" })
-    .click()
+  await projectsLink.focus()
+  await page.keyboard.press("Enter")
   await expect(page).toHaveURL(/\/projects\/$/)
   await expect(
     page.getByRole("heading", {
@@ -290,16 +305,39 @@ test("client navigation loads a lazy route and restores Home from history", asyn
       name: "Practical builds for real workflows",
     })
   ).toBeVisible()
+  await expect.poll(() => getViewportScrollY(page)).toBe(0)
+  await expect(page.locator("#main-content")).toBeFocused()
+  await expect(page.locator("#main-content")).toHaveAttribute("tabindex", "-1")
   expect(
     lazyScriptRequests.some((url) => /\/assets\/.*\.js(?:\?|$)/.test(url)),
     "Projects navigation should load a first-party lazy JavaScript chunk"
   ).toBe(true)
+
+  await setViewportScrollY(page, 300)
+  await expect
+    .poll(() => getViewportScrollY(page), {
+      message: "Projects route should be scrollable for history restoration",
+    })
+    .toBeGreaterThan(0)
+  const destinationScrollY = await getViewportScrollY(page)
+  expect(destinationScrollY).not.toBe(sourceScrollY)
 
   await page.goBack()
   await expect(page).toHaveURL(/\/$/)
   await expect(
     page.getByRole("heading", { level: 1, name: "Waffy Ahmed" })
   ).toBeVisible()
+  await expect.poll(() => getViewportScrollY(page)).toBe(sourceScrollY)
+
+  await page.goForward()
+  await expect(page).toHaveURL(/\/projects\/$/)
+  await expect(
+    page.getByRole("heading", {
+      level: 1,
+      name: "Practical builds for real workflows",
+    })
+  ).toBeVisible()
+  await expect.poll(() => getViewportScrollY(page)).toBe(destinationScrollY)
   expect(documentRequests).toHaveLength(1)
   monitor.assertClean()
 })

--- a/main/src/App.jsx
+++ b/main/src/App.jsx
@@ -13,6 +13,7 @@ import {
   Route,
   Routes,
   useLocation,
+  useNavigationType,
 } from "react-router"
 import Home from "./pages/Home.jsx"
 import Navbar from "./components/Navbar.jsx"
@@ -146,7 +147,12 @@ class RouteErrorBoundary extends Component {
 
 function App() {
   const location = useLocation()
-  const [displayedLocation, setDisplayedLocation] = useState(location)
+  const navigationType = useNavigationType()
+  const [displayedRoute, setDisplayedRoute] = useState(() => ({
+    location,
+    navigationType,
+  }))
+  const displayedLocation = displayedRoute.location
   const routePending = location.key !== displayedLocation.key
 
   useEffect(() => {
@@ -155,9 +161,22 @@ function App() {
     // Keep the router's URL and page-view semantics immediate, but update the
     // lazy route tree in a transition so its existing content stays visible.
     startTransition(() => {
-      setDisplayedLocation(location)
+      setDisplayedRoute({ location, navigationType })
     })
-  }, [displayedLocation.key, location])
+  }, [displayedLocation.key, location, navigationType])
+
+  useEffect(() => {
+    if (
+      displayedRoute.navigationType !== "PUSH" &&
+      displayedRoute.navigationType !== "REPLACE"
+    ) {
+      return
+    }
+
+    const scrollToTop = { top: 0, left: 0, behavior: "instant" }
+    window.scrollTo(scrollToTop)
+    document.getElementById("main-content")?.focus({ preventScroll: true })
+  }, [displayedRoute])
 
   usePageTracking()
   return (

--- a/main/src/App.lazy-route-error.test.jsx
+++ b/main/src/App.lazy-route-error.test.jsx
@@ -13,11 +13,13 @@ import App from "./App.jsx"
 afterEach(() => {
   cleanup()
   vi.restoreAllMocks()
+  vi.unstubAllGlobals()
 })
 
 it("preserves the shell and recovers from a rejected lazy route", async () => {
   const user = userEvent.setup()
 
+  vi.stubGlobal("scrollTo", vi.fn())
   vi.spyOn(console, "error").mockImplementation(() => {})
 
   render(

--- a/main/src/App.test.jsx
+++ b/main/src/App.test.jsx
@@ -159,10 +159,12 @@ beforeEach(() => {
       disconnect() {}
     }
   )
+  vi.stubGlobal("scrollTo", vi.fn())
 })
 
 afterEach(() => {
   cleanup()
+  vi.restoreAllMocks()
   document.getElementById("google-analytics-script")?.remove()
   delete window.__portfolioGaInitialized
   delete window.dataLayer
@@ -455,6 +457,61 @@ describe("App routes", () => {
       "/",
       "/projects/",
     ])
+  })
+
+  it("resets scroll and focuses the route main for forward navigation", async () => {
+    const user = userEvent.setup()
+    const scrollToMock = vi.fn()
+    const focusSpy = vi.spyOn(HTMLElement.prototype, "focus")
+    vi.stubGlobal("scrollTo", scrollToMock)
+    renderBrowserRoute("/")
+
+    await screen.findByRole("heading", { name: /waffy ahmed/i })
+    const projectsLink = within(
+      screen.getByRole("navigation", { name: /primary navigation/i })
+    ).getByRole("link", { name: /projects/i })
+
+    await user.click(projectsLink)
+    await screen.findByRole("heading", {
+      name: /practical builds for real workflows/i,
+    })
+
+    const main = screen.getByRole("main")
+    expect(main).toHaveAttribute("id", "main-content")
+    expect(main).toHaveAttribute("tabindex", "-1")
+    await waitFor(() =>
+      expect(scrollToMock).toHaveBeenCalledWith({
+        top: 0,
+        left: 0,
+        behavior: "instant",
+      })
+    )
+    expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true })
+    expect(main).toHaveFocus()
+  })
+
+  it("does not override scroll or focus during history navigation", async () => {
+    const scrollToMock = vi.fn()
+    const focusSpy = vi.spyOn(HTMLElement.prototype, "focus")
+    vi.stubGlobal("scrollTo", scrollToMock)
+    renderBrowserRoute("/")
+
+    await screen.findByRole("heading", { name: /waffy ahmed/i })
+    scrollToMock.mockClear()
+    focusSpy.mockClear()
+    window.history.pushState(
+      { key: "history-navigation", idx: 1 },
+      "",
+      "/projects/"
+    )
+    fireEvent.popState(window)
+
+    await screen.findByRole("heading", {
+      name: /practical builds for real workflows/i,
+    })
+
+    expect(scrollToMock).not.toHaveBeenCalled()
+    expect(focusSpy).not.toHaveBeenCalled()
   })
 
   it("excludes query strings and fragments from analytics page views", async () => {

--- a/main/src/components/MissionControl.jsx
+++ b/main/src/components/MissionControl.jsx
@@ -77,7 +77,11 @@ const diagramPositions = [
 ]
 
 export function PageShell({ children, className = "" }) {
-  return <main className={`mc-page ${className}`}>{children}</main>
+  return (
+    <main id="main-content" tabIndex={-1} className={`mc-page ${className}`}>
+      {children}
+    </main>
+  )
 }
 
 export function PageContainer({ children, className = "" }) {


### PR DESCRIPTION
## Summary

- reset forward SPA navigation to the top after the lazy route has committed
- move focus to the shared `main` landmark without adding it to the Tab order
- leave POP navigation untouched so browser back/forward scroll restoration remains intact
- cover forward keyboard navigation and history restoration at desktop and mobile widths

## Verification

- `npm run lint`
- `npm run test` (49 passed)
- `npm run build`
- `npm --prefix main run test:e2e:premerge -- --grep "client navigation resets forward scroll and preserves history scroll restoration"` (2 passed: desktop and mobile Chromium)
- `node .codex/skills/portfolio-change-impact/scripts/check_change_impact.mjs --source worktree --check`
- `git diff --check`

## Notes

- Browser QA used the local production preview with analytics and Formspree requests blocked by the existing test fixture.
- The targeted navigation regression ran in both configured Chromium projects; the full Playwright suite and production QA were not run.
- No content, SEO metadata, AI-discovery, analytics, CSP, dependency, or route-slug changes are included.

Refs #162