### PR TITLE
Add skip navigation and site-wide footer landmark

### DIFF
--- a/main/src/App.jsx
+++ b/main/src/App.jsx
@@ -16,8 +16,10 @@ import {
   useNavigationType,
 } from "react-router"
 import Home from "./pages/Home.jsx"
+import DeployDates from "./components/DeployDates.jsx"
 import Navbar from "./components/Navbar.jsx"
 import Seo from "./components/Seo.jsx"
+import { deployInfo } from "./data/profile.js"
 import usePageTracking from "./hooks/usePageTracking.jsx"
 
 const Resume = lazy(() => import("./pages/Resume.jsx"))
@@ -179,9 +181,22 @@ function App() {
   }, [displayedRoute])
 
   usePageTracking()
+
+  const handleSkipToMain = (event) => {
+    event.preventDefault()
+    document.getElementById("main-content")?.focus()
+  }
+
   return (
     <div className="flex min-h-screen w-full flex-col bg-[#F4F1EA]">
       <Seo />
+      <a
+        href="#main-content"
+        onClick={handleSkipToMain}
+        className="sr-only z-[60] rounded-md bg-[#0B1220] px-4 py-2 text-sm font-black text-white shadow-lg focus:fixed focus:left-4 focus:top-4 focus:not-sr-only focus:outline-hidden focus:ring-2 focus:ring-[#F96302] focus:ring-offset-2 focus:ring-offset-[#F4F1EA]"
+      >
+        Skip to main content
+      </a>
       <Navbar />
       <div className="flex-1 overflow-auto">
         <DelayedRoutePendingIndicator key={location.key} pending={routePending} />
@@ -210,6 +225,11 @@ function App() {
             </div>
           </Suspense>
         </RouteErrorBoundary>
+      </div>
+      <div className="bg-[#E8EDF2] px-3 py-4 sm:px-5">
+        <div className="mx-auto w-full max-w-6xl">
+          <DeployDates first={deployInfo.firstPublishedAt} />
+        </div>
       </div>
     </div>
   )

--- a/main/src/App.test.jsx
+++ b/main/src/App.test.jsx
@@ -313,7 +313,7 @@ describe("App routes", () => {
     const footer = screen.getByRole("contentinfo")
 
     expect(main).toHaveAttribute("id", "main-content")
-    expect(main).toHaveFocus()
+    await waitFor(() => expect(main).toHaveFocus())
     expect(footer).toContainElement(screen.getByText(/created:/i))
     expect(main).not.toContainElement(footer)
   })

--- a/main/src/App.test.jsx
+++ b/main/src/App.test.jsx
@@ -210,6 +210,136 @@ describe("App routes", () => {
     )
   })
 
+  it("makes the skip link the first focusable control and moves focus to the route main", async () => {
+    const user = userEvent.setup()
+    vi.stubGlobal("matchMedia", vi.fn(() => ({ matches: false })))
+    renderRoute("/")
+
+    await screen.findByRole("heading", { name: /waffy ahmed/i })
+    await user.tab()
+
+    const skipLink = screen.getByRole("link", { name: /skip to main content/i })
+    const main = screen.getByRole("main")
+
+    expect(skipLink).toHaveFocus()
+    expect(skipLink).toHaveClass("z-[60]", "focus:not-sr-only")
+    expect(main).toHaveAttribute("id", "main-content")
+    expect(main).toHaveAttribute("tabindex", "-1")
+
+    await user.keyboard("{Enter}")
+
+    expect(main).toHaveFocus()
+  })
+
+  it("keeps a mobile active nav link visible without scrolling the link itself", async () => {
+    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView
+    const originalScrollTo = HTMLElement.prototype.scrollTo
+    const scrollIntoViewMock = vi.fn()
+    const navScrollToMock = vi.fn()
+
+    try {
+      Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+        configurable: true,
+        value: scrollIntoViewMock,
+      })
+      Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+        configurable: true,
+        value: navScrollToMock,
+      })
+      vi.stubGlobal(
+        "matchMedia",
+        vi.fn((query) => ({
+          matches: query === "(prefers-reduced-motion: reduce)",
+        }))
+      )
+      vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+        function getBoundingClientRect() {
+          if (this.getAttribute("aria-label") === "Primary navigation") {
+            return { left: 0, right: 100 }
+          }
+
+          if (this.getAttribute("aria-current") === "page") {
+            return { left: 110, right: 160 }
+          }
+
+          return { left: 0, right: 0 }
+        }
+      )
+
+      renderRoute("/")
+      await screen.findByRole("heading", { name: /waffy ahmed/i })
+
+      expect(scrollIntoViewMock).not.toHaveBeenCalled()
+      expect(navScrollToMock).toHaveBeenCalledWith({
+        behavior: "auto",
+        left: 60,
+      })
+    } finally {
+      if (originalScrollIntoView) {
+        Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+          configurable: true,
+          value: originalScrollIntoView,
+        })
+      } else {
+        delete HTMLElement.prototype.scrollIntoView
+      }
+
+      if (originalScrollTo) {
+        Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+          configurable: true,
+          value: originalScrollTo,
+        })
+      } else {
+        delete HTMLElement.prototype.scrollTo
+      }
+    }
+  })
+
+  it("keeps the skip target and site footer available after in-app navigation", async () => {
+    const user = userEvent.setup()
+    renderBrowserRoute("/")
+
+    await screen.findByRole("heading", { name: /waffy ahmed/i })
+    const projectsLink = within(
+      screen.getByRole("navigation", { name: /primary navigation/i })
+    ).getByRole("link", { name: /projects/i })
+
+    await user.click(projectsLink)
+    await screen.findByRole("heading", {
+      name: /practical builds for real workflows/i,
+    })
+
+    const main = screen.getByRole("main")
+    const footer = screen.getByRole("contentinfo")
+
+    expect(main).toHaveAttribute("id", "main-content")
+    expect(main).toHaveFocus()
+    expect(footer).toContainElement(screen.getByText(/created:/i))
+    expect(main).not.toContainElement(footer)
+  })
+
+  it("keeps one main landmark and one h1 on every primary route", async () => {
+    for (const route of [
+      "/",
+      "/resume",
+      "/contact",
+      "/case-studies",
+      "/experience",
+      "/projects",
+    ]) {
+      const view = renderRoute(route)
+
+      await screen.findByRole("main")
+      await waitFor(() =>
+        expect(screen.getAllByRole("heading", { level: 1 })).toHaveLength(1)
+      )
+      expect(screen.getAllByRole("main")).toHaveLength(1)
+      expect(screen.getAllByRole("contentinfo")).toHaveLength(1)
+
+      view.unmount()
+    }
+  })
+
   it("preloads lazy routes when primary navigation shows intent", async () => {
     renderRoute("/")
 

--- a/main/src/components/Navbar.jsx
+++ b/main/src/components/Navbar.jsx
@@ -20,19 +20,37 @@ function Navbar() {
       return;
     }
 
-    const activeLink = navRef.current?.querySelector("[aria-current='page']");
+    const nav = navRef.current;
+    const activeLink = nav?.querySelector("[aria-current='page']");
 
     if (!activeLink || window.matchMedia("(min-width: 640px)").matches) {
       return;
     }
 
     const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    const navRect = nav.getBoundingClientRect();
+    const activeLinkRect = activeLink.getBoundingClientRect();
+    const isActiveLinkVisible =
+      activeLinkRect.left >= navRect.left && activeLinkRect.right <= navRect.right;
 
-    activeLink.scrollIntoView({
-      behavior: prefersReducedMotion ? "auto" : "smooth",
-      block: "nearest",
-      inline: "nearest",
-    });
+    if (isActiveLinkVisible) {
+      return;
+    }
+
+    const scrollOffset =
+      activeLinkRect.left < navRect.left
+        ? activeLinkRect.left - navRect.left
+        : activeLinkRect.right - navRect.right;
+    const left = Math.max(0, nav.scrollLeft + scrollOffset);
+
+    if (typeof nav.scrollTo === "function") {
+      nav.scrollTo({
+        behavior: prefersReducedMotion ? "auto" : "smooth",
+        left,
+      });
+    } else {
+      nav.scrollLeft = left;
+    }
   }, [location.pathname]);
 
   return (

--- a/main/src/pages/Home.jsx
+++ b/main/src/pages/Home.jsx
@@ -10,7 +10,6 @@ import {
   FaRegClock,
   FaServer,
 } from "react-icons/fa";
-import DeployDates from "../components/DeployDates";
 import {
   ImpactBand,
   PageContainer,
@@ -21,7 +20,7 @@ import {
   SystemDiagram,
 } from "../components/MissionControl.jsx";
 import SocialLinks from "../components/SocialLinks";
-import { deployInfo, profile, resume } from "../data/profile";
+import { profile, resume } from "../data/profile";
 import { currentEmployment } from "../data/siteIdentity.js";
 import { trackEvent } from "../utils/analytics";
 import { createRouteIntentHandlers } from "../utils/routePrefetch.js";
@@ -300,8 +299,6 @@ function Home() {
             <p className="text-sm font-black uppercase text-slate-500">Connect</p>
             <SocialLinks placement="home" className="mt-4 flex flex-wrap gap-2" />
           </div>
-
-          <DeployDates first={deployInfo.firstPublishedAt} />
         </PageContainer>
       </section>
     </PageShell>


### PR DESCRIPTION
## Summary

- add a visible-on-focus skip link before the repeated site navigation and focus the stable route main target on activation
- keep mobile active-nav scrolling from changing Chromium's sequential keyboard-focus starting point
- move the existing deploy-date footer into the app shell so every route exposes one document-level `contentinfo` landmark outside `main`
- add regression coverage for skip-link focus, route-transition focus, mobile nav scrolling, and landmark/heading counts across primary routes

## Verification

- `npm --prefix main test -- --run src/App.test.jsx` (39 focused route/accessibility tests)
- portfolio release preflight: lint, 53 tests, and production build
- staged change-impact validation: SPA/SEO, GA4 contract, and frontend performance policy
- `git diff --staged --check`
- localhost keyboard QA at 1440x900 and 390x844 across `/`, `/projects/`, `/experience/`, `/case-studies/`, `/resume/`, and `/contact/`
- confirmed first Tab reaches the visible skip link, Enter focuses `main#main-content`, each route has one `main`, one H1, and one footer outside `main`, active mobile navigation remains visible, and no horizontal overflow or console errors appear
- confirmed keyboard-only Home to Projects navigation restores focus to the stable main target at both viewport sizes

## Scope

- localhost browser QA only; no production analytics traffic, deployment, release, issue closure, or Project mutation

Refs #171
