### PR TITLE
Add review-gated version and token evidence

### DIFF
--- a/.codex/skills/git-pr-publisher/SKILL.md
+++ b/.codex/skills/git-pr-publisher/SKILL.md
@@ -66,6 +66,7 @@ Do only the actions covered by that instruction or grant. A project plan, issue,
    - When updating an existing PR, preserve its labels unless the user asks to revise them.
    - Create a draft PR only if the user asks for draft or the branch is intentionally not ready for review.
    - Write a PR body with a short summary, verification performed, and any known risks or skipped checks.
+   - When `$review-gated-engineering` is active, refresh its Semantic Version Assessment against the final exact base-to-head diff and current published/version state. Include the required section below; this refresh is binding for the PR and does not grant a version bump, merge, release, or deployment.
    - Link work items with non-closing syntax such as `Refs #123`. Do not use `Fixes`, `Closes`, or equivalent keywords during implementation or review.
 
 8. Stop at the review boundary.
@@ -108,6 +109,15 @@ Common mistakes: validate names against the current label list instead of guessi
 
 ## Verification
 - ...
+
+## Semantic Version Assessment
+- Current version: ...
+- Published version: ...
+- Decision: `none | patch | minor | major | release-carrier`
+- Proposed version: ...
+- Basis: exact `<base SHA>...<head SHA>` diff and current published/version state at `<UTC time>`
+- Rationale/evidence: ...
+- Deferred status: ...
 
 ## Notes
 - ...

--- a/.codex/skills/review-gated-engineering/SKILL.md
+++ b/.codex/skills/review-gated-engineering/SKILL.md
@@ -15,6 +15,7 @@ At the start of a workflow:
 2. Classify the work by its highest-risk dimension and record the tier and rationale.
 3. Establish the active authority from a direct human instruction in the current conversation.
 4. Version the plan and use the applicable packet from [references/handoff-contracts.md](references/handoff-contracts.md). Read that reference before producing or consuming a packet.
+5. Make a provisional semantic-version assessment during planning. Read [references/semantic-versioning.md](references/semantic-versioning.md) when the work could affect a release, version, PR, or deployment.
 
 ## Select The Workflow
 
@@ -96,6 +97,14 @@ A direct request that clearly asks for implementation through a reviewable PR ca
 Under `IMPLEMENT_LOCAL`, stop after local checks and return the local implementation handoff. This is not a review verdict or merge-ready state. Resume publication only after a direct `IMPLEMENT_TO_PR` grant, then create the reviewable PR and obtain independent review.
 
 Never push directly to `main`. Never infer permission to merge, enable auto-merge, tag, create a GitHub Release, dispatch a release/deploy workflow, mutate production, close work, validate after merge, or remediate from implementation authority or a reviewer verdict.
+
+## Version And Usage Evidence
+
+Use [references/semantic-versioning.md](references/semantic-versioning.md) for the required semantic assessment vocabulary and lifecycle. Record a provisional assessment in planning, then refresh a binding assessment at PR creation from the exact base-to-head diff and current published/version state. The primary implementation PR must not edit `main/package.json` or `main/package-lock.json` merely to carry its proposed bump.
+
+If an implementation needs a version bump, it becomes eligible only after its exact merge and deployment are verified. A new direct `IMPLEMENT_TO_PR` grant is then required for a dedicated version-only PR. That PR is `release-carrier`, never recursively creates another bump, and still follows independent review, exact merge authorization, post-merge verification, and a separate `RELEASE_OR_DEPLOY` grant before semantic publication. No future authority is transferred by an assessment, PR, merge, review, or deployment.
+
+At every workflow human gate and terminal handoff, capture the locally observable token-usage breakdown described in [references/token-usage.md](references/token-usage.md). Use the bundled collector when session JSONL is available. Report requested and actual model/effort separately, preserve unavailable values, state snapshot coverage, and state that the final report response and later turns are excluded because they cannot be observed before delivery.
 
 Before recommending or executing merge, reinspect `.github/workflows/release-on-deploy.yml`. While a push to `main` automatically verifies the app, waits for the exact Netlify production deploy, validates production, creates a deploy tag and GitHub Release, and runs advisory production browser checks, a valid `MERGE_PR` grant must name the PR, reviewed head SHA, and merge method and acknowledge that compound consequence. Issue closure remains separate.
 

--- a/.codex/skills/review-gated-engineering/references/handoff-contracts.md
+++ b/.codex/skills/review-gated-engineering/references/handoff-contracts.md
@@ -77,7 +77,7 @@ Field meanings:
 
 ## Semantic Version Assessment
 
-Include this block in every planning packet. Refresh it at PR creation using the exact base-to-head diff, then carry that binding record into review and human-gate packets. Read [semantic-versioning.md](semantic-versioning.md) before completing it.
+Include this block in every planning packet. Before a PR exists, carry the current provisional record into any local implementation human-gate packet. At PR creation, refresh it using the exact base-to-head diff, then carry that binding record into review and later human-gate packets. Read [semantic-versioning.md](semantic-versioning.md) before completing it.
 
 ```yaml
 semantic_version_assessment:
@@ -197,7 +197,7 @@ local_implementation_handoff:
     - command_or_check: <exact command or inspection>
       result: <pass, fail, blocked, or not run with concise evidence>
       evidence_scope: <what this result proves>
-  semantic_version_assessment: <copy the binding Semantic Version Assessment block>
+  semantic_version_assessment: <copy the current provisional Semantic Version Assessment block; it remains provisional until PR creation>
   token_usage_snapshot: <copy the required Token Usage Snapshot block>
   plan_deviations:
     - deviation: <difference from the approved plan, or none>

--- a/.codex/skills/review-gated-engineering/references/handoff-contracts.md
+++ b/.codex/skills/review-gated-engineering/references/handoff-contracts.md
@@ -75,6 +75,59 @@ Field meanings:
 - scope, non-goals, and open questions make drift visible.
 - `next_allowed_transition` describes what current authority permits; `stop_condition` prevents a role from silently entering a later phase.
 
+## Semantic Version Assessment
+
+Include this block in every planning packet. Refresh it at PR creation using the exact base-to-head diff, then carry that binding record into review and human-gate packets. Read [semantic-versioning.md](semantic-versioning.md) before completing it.
+
+```yaml
+semantic_version_assessment:
+  current_version: <authoritative main/package.json version, unavailable, or none>
+  published_version: <latest published semantic version, unavailable, or none>
+  decision: <none | patch | minor | major | release-carrier>
+  proposed_version: <core version when decision is patch/minor/major; none otherwise>
+  rationale_and_evidence:
+    - <diff and published-state evidence supporting the decision>
+  assessment_basis: <provisional planning scope, or exact base-to-head diff at PR creation>
+  base_sha: <full SHA, or none before known>
+  head_sha: <full SHA, or none before known>
+  assessed_at: <UTC timestamp>
+  deferred_status: <not deferred, or exact later lifecycle and required grant>
+```
+
+## Token Usage Snapshot
+
+Every human-gate or terminal handoff must append a snapshot from the locally available telemetry. Read [token-usage.md](token-usage.md). Do not estimate unavailable fields or double-count cached/cache-write input or reasoning output.
+
+```yaml
+token_usage_snapshot:
+  source: <collector command and session root ID, or unavailable with reason>
+  snapshot_at: <UTC timestamp>
+  telemetry_through: <latest included telemetry timestamp, or unavailable>
+  coverage: <linked sessions and time boundary included; omissions and warnings>
+  requested_routing: <requested model/effort by phase or unavailable>
+  actual_routing: <actual model/effort from turn_context, or unavailable>
+  groups:
+    - phase: <phase or unavailable>
+      role: <role or unavailable>
+      session: <session ID>
+      requested_model: <value or unavailable>
+      requested_effort: <value or unavailable>
+      actual_model: <value or unavailable>
+      actual_effort: <value or unavailable>
+      response_count: <count or unavailable>
+      input: <count or unavailable>
+      cached_input: <count or unavailable>
+      cache_write_input: <count or unavailable>
+      uncached_input: <derived count or unavailable>
+      output: <count or unavailable>
+      reasoning_output: <count or unavailable>
+      total: <input plus output, or unavailable>
+  aggregate: <per-metric observed subtotal plus complete/partial unavailable-group coverage>
+  exclusions: <state that the final report response and later turns are excluded before delivery>
+```
+
+The required `groups` fields are an output contract, not permission to inspect arbitrary session contents. The collector reads only session metadata, turn context, and token-count telemetry.
+
 ## Planner To Implementer
 
 Append this block to the common metadata. Use it only after the plan is sufficiently resolved for the active tier and the authority record contains `IMPLEMENT_LOCAL` or `IMPLEMENT_TO_PR`.
@@ -144,6 +197,8 @@ local_implementation_handoff:
     - command_or_check: <exact command or inspection>
       result: <pass, fail, blocked, or not run with concise evidence>
       evidence_scope: <what this result proves>
+  semantic_version_assessment: <copy the binding Semantic Version Assessment block>
+  token_usage_snapshot: <copy the required Token Usage Snapshot block>
   plan_deviations:
     - deviation: <difference from the approved plan, or none>
       materiality: <non-material or material>
@@ -192,6 +247,8 @@ implementer_to_reviewer:
     - command_or_check: <exact command or inspection>
       result: <pass, fail, blocked, or not run with concise evidence>
       evidence_scope: <what this result proves>
+  semantic_version_assessment: <copy the binding Semantic Version Assessment block>
+  token_usage_snapshot: <copy the required Token Usage Snapshot block>
   plan_deviations:
     - deviation: <difference from the approved plan, or none>
       materiality: <non-material or material>
@@ -244,6 +301,19 @@ Use this report shape:
 ## Routing Telemetry
 
 For each role that ran, report requested capability/model/effort, routing source, actual model/effort, and evidence from the common packet. State `unknown` or `unavailable` for actual values when runtime metadata did not expose them; never infer actual values from a policy or prompt.
+
+## Binding Semantic Version Assessment
+
+- Current and published version: <values or unavailable>
+- Decision and proposed version: <one classifier value and proposed core version or none>
+- Exact basis: <base SHA, head SHA, current-state evidence, and UTC assessment time>
+- Deferred status: <later lifecycle and required grant, or not deferred>
+
+## Token Usage Snapshot
+
+- Source, snapshot time, and coverage: <collector command, selected linked sessions, time boundary, and warnings>
+- Breakdown: <phase/role/session/model/effort groups with response count, input, cached input, cache-write input, uncached input, output, reasoning output, and total; unavailable is explicit>
+- Exclusions: <state final report response and later turns are excluded before delivery>
 
 ## Findings
 

--- a/.codex/skills/review-gated-engineering/references/routing-policy.md
+++ b/.codex/skills/review-gated-engineering/references/routing-policy.md
@@ -10,6 +10,8 @@ When both `model` and `reasoning_effort` are exposed, every delegated planner, i
 
 The spawn result or another runtime/session metadata source is the only evidence for an actual selected model or effort. If it does not expose those fields, record `actual_model: unknown` and `actual_reasoning_effort: unknown`; do not infer them from the requested override.
 
+At a human gate or terminal state, retain the requested spawn values and collect actual per-segment model/effort from session `turn_context` when locally available. Use the token-usage reference and collector; requested routing is not evidence of actual routing.
+
 ## Capability Mapping And Safe Fallback
 
 Resolve classes from the live override list in this order:
@@ -62,5 +64,6 @@ Use these cases when changing or forward-testing this policy. Evaluate the routi
 | Post-review change | Reviewer delivered verdict for exact SHA; new commit/rebase/base change follows | Invalidate the verdict and any SHA-bound recommendation/grant; require fresh independent review before the human gate. |
 | Base-tip-only drift | Reviewer packet and verdict name a full `reviewed_base_tip_sha`; the base branch advances while merge-base and head SHA remain unchanged | Immediately before review and downstream execution, compare the live base tip with `reviewed_base_tip_sha`; on mismatch, invalidate the verdict and every SHA-bound recommendation/grant and require fresh review or authorization. |
 | Routing and authority | Any model/effort/fallback decision under limited grant | The routing record does not expand `IMPLEMENT_LOCAL`, `IMPLEMENT_TO_PR`, merge, deployment, production, remediation, or closure authority; stop at the existing phase boundary. |
+| Usage telemetry unavailable | Selected linked session has no complete `token_count` fields or no `turn_context` | Report the affected metrics or actual route as unavailable with warnings; do not substitute zeroes, estimates, or requested routing. |
 
 For this skill update, independently inspect the live session tool definition before reporting that overrides are supported. The policy can prove requested spawn arguments and fallback behavior; it cannot prove an actual child model/effort without runtime metadata.

--- a/.codex/skills/review-gated-engineering/references/semantic-versioning.md
+++ b/.codex/skills/review-gated-engineering/references/semantic-versioning.md
@@ -1,0 +1,15 @@
+# Semantic Version Assessment
+
+Read this reference during planning when a change could affect a release, and again immediately before creating a review-gated PR.
+
+Use exactly one decision: `none`, `patch`, `minor`, `major`, or `release-carrier`.
+
+- `none`: no deployable portfolio contract change that merits a semantic release.
+- `patch`: compatible corrective change.
+- `minor`: compatible additive product change.
+- `major`: incompatible product contract change from `1.0.0` onward; before `1.0.0`, follow the repository policy that treats intentionally breaking or substantial milestones as `minor`.
+- `release-carrier`: a dedicated version-only PR following a verified deployment; it never schedules another carrier.
+
+Use [docs/release-versioning.md](../../../../docs/release-versioning.md) as the repository source of truth. Planning is provisional. At PR creation, inspect the exact base-to-head diff and refresh current authoritative `main/package.json` and published semantic-release state. Record current version, decision, proposed version when applicable, rationale/evidence, basis, base/head SHA, UTC time, and deferred status in the PR and handoff contract.
+
+The primary implementation PR must not change `main/package.json` or `main/package-lock.json` simply to carry its own proposed bump. If it needs a bump, wait for its exact merge and production deployment to be verified. A new direct `IMPLEMENT_TO_PR` grant is required for a dedicated version-only `release-carrier` PR. It remains independently reviewable and needs later exact merge authorization, post-merge verification, and a separate `RELEASE_OR_DEPLOY` grant before publishing. Neither an assessment nor a prior grant transfers any future authority.

--- a/.codex/skills/review-gated-engineering/references/token-usage.md
+++ b/.codex/skills/review-gated-engineering/references/token-usage.md
@@ -1,0 +1,20 @@
+# Token Usage Snapshots
+
+At every workflow human gate and terminal handoff, run the collector when the local Codex session JSONL is available:
+
+```bash
+python3 .codex/skills/review-gated-engineering/scripts/summarize_token_usage.py \
+  --root-session-id <root-session-id> \
+  --since <workflow-start-UTC> \
+  --phase <workflow-phase> \
+  --requested-model <requested-model> \
+  --requested-effort <requested-effort>
+```
+
+For mixed delegated work, repeat `--session-label 'SESSION=PHASE|ROLE|REQUESTED_MODEL|REQUESTED_EFFORT'`. It overrides only the report labels for that unique session ID; actual model/effort still come from `turn_context`.
+
+Use `--format markdown` for a packet and `--format json` for machine-readable evidence. The collector is read-only and deterministic apart from its recorded UTC collection time. It normalizes the first metadata record immediately to only identifiers, linkage, role/path, and start time, then extracts only selected-session metadata, `turn_context`, and `token_count` telemetry. It neither retains, prints, nor persists prompts, responses, instructions, tool inputs, or tool outputs.
+
+Each group is phase, role, session, actual model, and actual effort. It reports response count, input, cached input, cache-write input, derived uncached input, output, reasoning output, and total. Cached/cache-write are subsets of input, reasoning output is a subset of output, and total is input plus output: none are added twice. Requested model/effort are user-supplied labels, while actual values come only from `turn_context`.
+
+Missing or inconsistent telemetry produces warnings and `unavailable`, never invented zeroes or estimates. The report records both its UTC collection time and the latest included telemetry observation. Its aggregate table is a complete total only when every selected group has that metric; otherwise it is an observed subtotal with unavailable-group coverage. State those times and linked-session coverage in the handoff. The report's own final response and later turns are excluded because they are not observable before delivery.

--- a/.codex/skills/review-gated-engineering/scripts/summarize_token_usage.py
+++ b/.codex/skills/review-gated-engineering/scripts/summarize_token_usage.py
@@ -36,6 +36,8 @@ def metadata_from(path: Path) -> dict[str, Any] | None:
             record = json.loads(handle.readline())
     except (OSError, json.JSONDecodeError):
         return None
+    if not isinstance(record, dict):
+        return None
     if record.get("type") != "session_meta" or not isinstance(record.get("payload"), dict):
         return None
     # Never retain arbitrary session metadata (which can include instructions).
@@ -191,7 +193,7 @@ def select_sessions(session_dir: Path, root_session_id: str, since: datetime) ->
 
 
 def number(value: Any) -> int | None:
-    return value if isinstance(value, int) and value >= 0 else None
+    return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else None
 
 
 def empty_metrics() -> dict[str, int | None]:
@@ -265,6 +267,10 @@ def summarize_selected(
                     commit_pending()
                     warnings.append(f"ignored malformed JSONL record in {path.name}")
                     continue
+                if not isinstance(record, dict):
+                    commit_pending()
+                    warnings.append(f"ignored non-object JSONL record in {path.name}")
+                    continue
                 record_type = record.get("type")
                 payload = record.get("payload")
                 if pending_observation is not None:
@@ -301,12 +307,15 @@ def summarize_selected(
                     continue
                 if observed_at < since:
                     continue
-                usage = payload.get("info", {}).get("last_token_usage")
+                info = payload.get("info")
+                usage = info.get("last_token_usage") if isinstance(info, dict) else None
                 if not isinstance(usage, dict):
                     warnings.append(f"missing last_token_usage in {path.name}")
                     continue
                 values = {key: number(usage.get(key)) for key in TOKEN_KEYS}
                 reported_total = number(usage.get("total_tokens"))
+                if any(isinstance(usage.get(key), bool) for key in TOKEN_KEYS + ("total_tokens",)):
+                    warnings.append(f"invalid boolean token metric in {path.name}")
                 zero_components = all(value == 0 for value in values.values())
                 if compaction_pending and zero_components and reported_total not in (None, 0):
                     ignored_compaction_baselines[session_id] += 1

--- a/.codex/skills/review-gated-engineering/scripts/summarize_token_usage.py
+++ b/.codex/skills/review-gated-engineering/scripts/summarize_token_usage.py
@@ -33,8 +33,12 @@ def parse_time(value: str) -> datetime:
 def metadata_from(path: Path) -> dict[str, Any] | None:
     try:
         with path.open(encoding="utf-8") as handle:
-            record = json.loads(handle.readline())
-    except (OSError, json.JSONDecodeError):
+            first_line = handle.readline()
+    except OSError:
+        return None
+    try:
+        record = json.loads(first_line)
+    except (json.JSONDecodeError, ValueError, RecursionError):
         return None
     if not isinstance(record, dict):
         return None
@@ -266,6 +270,10 @@ def summarize_selected(
                 except json.JSONDecodeError:
                     commit_pending()
                     warnings.append(f"ignored malformed JSONL record in {path.name}")
+                    continue
+                except (ValueError, RecursionError):
+                    commit_pending()
+                    warnings.append(f"ignored decoder-rejected JSONL record in {path.name}")
                     continue
                 if not isinstance(record, dict):
                     commit_pending()

--- a/.codex/skills/review-gated-engineering/scripts/summarize_token_usage.py
+++ b/.codex/skills/review-gated-engineering/scripts/summarize_token_usage.py
@@ -224,6 +224,7 @@ def summarize_selected(
     groups: dict[tuple[str, str, str, str, str], list[dict[str, int | None]]] = defaultdict(list)
     warnings: list[str] = []
     latest_observation: datetime | None = None
+    ignored_compaction_baselines: dict[str, int] = defaultdict(int)
     for path, metadata in selected:
         session_id = session_identity(metadata, path.stem)
         label = labels.get(session_id)
@@ -233,6 +234,7 @@ def summarize_selected(
         model = "unavailable"
         effort = "unavailable"
         telemetry_seen = False
+        compaction_pending = False
         try:
             handle = path.open(encoding="utf-8")
         except OSError as error:
@@ -252,6 +254,9 @@ def summarize_selected(
                 if record_type == "turn_context":
                     model = payload.get("model") if isinstance(payload.get("model"), str) else "unavailable"
                     effort = payload.get("effort") if isinstance(payload.get("effort"), str) else "unavailable"
+                    continue
+                if record_type == "compacted":
+                    compaction_pending = True
                     continue
                 if record_type != "event_msg" or payload.get("type") != "token_count":
                     continue
@@ -273,6 +278,12 @@ def summarize_selected(
                     continue
                 values = {key: number(usage.get(key)) for key in TOKEN_KEYS}
                 reported_total = number(usage.get("total_tokens"))
+                zero_components = all(value == 0 for value in values.values())
+                if compaction_pending and zero_components and reported_total not in (None, 0):
+                    ignored_compaction_baselines[session_id] += 1
+                    continue
+                # The next non-marker token record resumes ordinary validation.
+                compaction_pending = False
                 total_consistent = (
                     reported_total is None
                     or values["input_tokens"] is None
@@ -334,6 +345,8 @@ def summarize_selected(
         warnings.append("no usable token_count telemetry found in selected sessions")
     if any(row["response_count"] is None for row in rows):
         warnings.append("selected session has no usable token telemetry after the time boundary")
+    for session_id, count in sorted(ignored_compaction_baselines.items()):
+        warnings.append(f"ignored {count} post-compaction zero-component token baseline(s) for session {session_id}")
     return rows, warnings, latest_observation
 
 

--- a/.codex/skills/review-gated-engineering/scripts/summarize_token_usage.py
+++ b/.codex/skills/review-gated-engineering/scripts/summarize_token_usage.py
@@ -225,6 +225,7 @@ def summarize_selected(
     warnings: list[str] = []
     latest_observation: datetime | None = None
     ignored_compaction_baselines: dict[str, int] = defaultdict(int)
+    ignored_relay_snapshots: dict[str, int] = defaultdict(int)
     for path, metadata in selected:
         session_id = session_identity(metadata, path.stem)
         label = labels.get(session_id)
@@ -235,6 +236,22 @@ def summarize_selected(
         effort = "unavailable"
         telemetry_seen = False
         compaction_pending = False
+        last_counted_fingerprint: tuple[int | None, ...] | None = None
+        pending_observation: tuple[
+            tuple[str, str, str, str, str], dict[str, int | None], tuple[int | None, ...], datetime
+        ] | None = None
+
+        def commit_pending() -> None:
+            nonlocal pending_observation, telemetry_seen, latest_observation, last_counted_fingerprint
+            if pending_observation is None:
+                return
+            key, observation, fingerprint, observed_at = pending_observation
+            groups[key].append(observation)
+            telemetry_seen = True
+            last_counted_fingerprint = fingerprint
+            latest_observation = max(latest_observation, observed_at) if latest_observation else observed_at
+            pending_observation = None
+
         try:
             handle = path.open(encoding="utf-8")
         except OSError as error:
@@ -245,10 +262,23 @@ def summarize_selected(
                 try:
                     record = json.loads(line)
                 except json.JSONDecodeError:
+                    commit_pending()
                     warnings.append(f"ignored malformed JSONL record in {path.name}")
                     continue
                 record_type = record.get("type")
                 payload = record.get("payload")
+                if pending_observation is not None:
+                    if (
+                        record_type == "inter_agent_communication_metadata"
+                        and isinstance(payload, dict)
+                        and payload.get("trigger_turn") is False
+                        and all(value is not None for value in pending_observation[2])
+                        and pending_observation[2] == last_counted_fingerprint
+                    ):
+                        ignored_relay_snapshots[session_id] += 1
+                        pending_observation = None
+                    else:
+                        commit_pending()
                 if not isinstance(payload, dict):
                     continue
                 if record_type == "turn_context":
@@ -271,7 +301,6 @@ def summarize_selected(
                     continue
                 if observed_at < since:
                     continue
-                latest_observation = max(latest_observation, observed_at) if latest_observation else observed_at
                 usage = payload.get("info", {}).get("last_token_usage")
                 if not isinstance(usage, dict):
                     warnings.append(f"missing last_token_usage in {path.name}")
@@ -302,15 +331,17 @@ def summarize_selected(
                 if not reasoning_consistent:
                     warnings.append(f"reasoning output exceeds output telemetry in {path.name}")
                 key = (session_phase, role, session_id, model, effort)
-                groups[key].append({
+                fingerprint = tuple(values[token_key] for token_key in TOKEN_KEYS) + (reported_total,)
+                pending_observation = (key, {
                     "input": values["input_tokens"],
                     "cached_input": values["cached_input_tokens"],
                     "cache_write_input": values["cache_write_input_tokens"],
                     "output": values["output_tokens"],
                     "reasoning_output": values["reasoning_output_tokens"] if reasoning_consistent else None,
                     "total_consistent": int(total_consistent),
-                })
-                telemetry_seen = True
+                }, fingerprint, observed_at)
+
+        commit_pending()
 
         if not telemetry_seen:
             groups.setdefault((session_phase, role, session_id, model, effort), [])
@@ -347,6 +378,8 @@ def summarize_selected(
         warnings.append("selected session has no usable token telemetry after the time boundary")
     for session_id, count in sorted(ignored_compaction_baselines.items()):
         warnings.append(f"ignored {count} post-compaction zero-component token baseline(s) for session {session_id}")
+    for session_id, count in sorted(ignored_relay_snapshots.items()):
+        warnings.append(f"ignored {count} inter-agent relay token snapshot(s) for session {session_id}")
     return rows, warnings, latest_observation
 
 

--- a/.codex/skills/review-gated-engineering/scripts/summarize_token_usage.py
+++ b/.codex/skills/review-gated-engineering/scripts/summarize_token_usage.py
@@ -1,0 +1,438 @@
+#!/usr/bin/env python3
+"""Summarize Codex token telemetry without exposing session content."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+TOKEN_KEYS = (
+    "input_tokens",
+    "cached_input_tokens",
+    "cache_write_input_tokens",
+    "output_tokens",
+    "reasoning_output_tokens",
+)
+
+
+def parse_time(value: str) -> datetime:
+    if value.endswith("Z"):
+        value = f"{value[:-1]}+00:00"
+    parsed = datetime.fromisoformat(value)
+    if parsed.tzinfo is None:
+        raise ValueError("time boundary must include a UTC offset or Z")
+    return parsed.astimezone(timezone.utc)
+
+
+def metadata_from(path: Path) -> dict[str, Any] | None:
+    try:
+        with path.open(encoding="utf-8") as handle:
+            record = json.loads(handle.readline())
+    except (OSError, json.JSONDecodeError):
+        return None
+    if record.get("type") != "session_meta" or not isinstance(record.get("payload"), dict):
+        return None
+    # Never retain arbitrary session metadata (which can include instructions).
+    # Linkage, identity, route, and start-time fields are the entire index schema.
+    payload = record["payload"]
+    metadata = {
+        key: payload[key]
+        for key in ("id", "session_id", "timestamp", "parent_thread_id", "forked_from_id", "agent_role", "agent_path")
+        if isinstance(payload.get(key), str)
+    }
+    source = payload.get("source")
+    subagent = source.get("subagent") if isinstance(source, dict) else None
+    if isinstance(subagent, dict):
+        safe_subagent = {"other": subagent["other"]} if isinstance(subagent.get("other"), str) else {}
+        for key in ("agent_role", "agent_path"):
+            if isinstance(subagent.get(key), str):
+                safe_subagent[key] = subagent[key]
+        spawn = subagent.get("thread_spawn")
+        if isinstance(spawn, dict):
+            safe_spawn = {
+                key: spawn[key]
+                for key in ("parent_thread_id", "agent_role", "agent_path")
+                if isinstance(spawn.get(key), str)
+            }
+            if safe_spawn:
+                safe_subagent["thread_spawn"] = safe_spawn
+        if safe_subagent:
+            metadata["source"] = {"subagent": safe_subagent}
+    return metadata
+
+
+def session_index(session_dir: Path) -> list[tuple[Path, dict[str, Any]]]:
+    indexed = []
+    for path in sorted(session_dir.rglob("*.jsonl")):
+        metadata = metadata_from(path)
+        if metadata is not None:
+            indexed.append((path, metadata))
+    return indexed
+
+
+def metadata_time(metadata: dict[str, Any]) -> datetime | None:
+    value = metadata.get("timestamp")
+    if not isinstance(value, str):
+        return None
+    try:
+        return parse_time(value)
+    except ValueError:
+        return None
+
+
+def metadata_ids(metadata: dict[str, Any]) -> set[str]:
+    return {value for key in ("session_id", "id") if isinstance((value := metadata.get(key)), str)}
+
+
+def session_identity(metadata: dict[str, Any], fallback: str) -> str:
+    for key in ("id", "session_id"):
+        value = metadata.get(key)
+        if isinstance(value, str):
+            return value
+    return fallback
+
+
+def subagent_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
+    source = metadata.get("source")
+    if not isinstance(source, dict):
+        return {}
+    subagent = source.get("subagent")
+    return subagent if isinstance(subagent, dict) else {}
+
+
+def parent_ids(metadata: dict[str, Any]) -> set[str]:
+    links = {
+        value
+        for key in ("parent_thread_id", "forked_from_id")
+        if isinstance((value := metadata.get(key)), str)
+    }
+    subagent = subagent_metadata(metadata)
+    spawn = subagent.get("thread_spawn")
+    if isinstance(spawn, dict) and isinstance(spawn.get("parent_thread_id"), str):
+        links.add(spawn["parent_thread_id"])
+    if subagent.get("other") == "guardian" and isinstance(metadata.get("session_id"), str):
+        links.add(metadata["session_id"])
+    return links
+
+
+def derived_role(metadata: dict[str, Any], root_session_id: str) -> str:
+    if metadata.get("id") == root_session_id:
+        return "coordinator"
+    subagent = subagent_metadata(metadata)
+    if subagent.get("other") == "guardian":
+        return "guardian"
+    spawn = subagent.get("thread_spawn") if isinstance(subagent.get("thread_spawn"), dict) else {}
+    for source in (metadata, spawn):
+        value = source.get("agent_role")
+        if isinstance(value, str) and value:
+            return value
+    for source in (metadata, spawn):
+        path = source.get("agent_path")
+        if isinstance(path, str) and path.strip("/"):
+            return f"agent:{path.rstrip('/').split('/')[-1]}"
+    return "unavailable"
+
+
+def parse_labels(values: list[str]) -> dict[str, tuple[str, str, str, str]]:
+    labels = {}
+    for value in values:
+        session, separator, fields = value.partition("=")
+        parts = fields.split("|")
+        if not separator or not session or len(parts) != 4 or any(not part for part in parts):
+            raise ValueError("session labels must be SESSION=PHASE|ROLE|REQUESTED_MODEL|REQUESTED_EFFORT")
+        labels[session] = tuple(parts)  # type: ignore[assignment]
+    return labels
+
+
+def select_sessions(session_dir: Path, root_session_id: str, since: datetime) -> tuple[list[tuple[Path, dict[str, Any]]], list[str]]:
+    indexed = session_index(session_dir)
+    warnings: list[str] = []
+    identities: dict[str, tuple[Path, dict[str, Any]]] = {}
+    for path, metadata in indexed:
+        identity = metadata.get("id")
+        if isinstance(identity, str):
+            identities[identity] = (path, metadata)
+
+    exact_roots = [(path, metadata) for path, metadata in indexed if metadata.get("id") == root_session_id]
+    root = exact_roots[0] if len(exact_roots) == 1 else identities.get(root_session_id)
+    if root is None:
+        candidates = [(path, metadata) for path, metadata in indexed if root_session_id in path.name]
+        root = candidates[0] if len(candidates) == 1 else None
+    if root is None:
+        raise ValueError(f"root session ID not found: {root_session_id}")
+
+    selected_ids = metadata_ids(root[1]) | {root_session_id}
+    selected_paths = {root[0]}
+    changed = True
+    while changed:
+        changed = False
+        for path, metadata in indexed:
+            if path not in selected_paths and parent_ids(metadata) & selected_ids:
+                selected_paths.add(path)
+                selected_ids.update(metadata_ids(metadata))
+                changed = True
+
+    selected = []
+    for path, metadata in indexed:
+        if path not in selected_paths:
+            continue
+        started = metadata_time(metadata)
+        if path != root[0] and (started is None or started < since):
+            warnings.append(f"excluded descendant {path.name}: outside or missing time boundary")
+            continue
+        selected.append((path, metadata))
+    return selected, warnings
+
+
+def number(value: Any) -> int | None:
+    return value if isinstance(value, int) and value >= 0 else None
+
+
+def empty_metrics() -> dict[str, int | None]:
+    return {
+        "response_count": 0,
+        "input": 0,
+        "cached_input": 0,
+        "cache_write_input": 0,
+        "uncached_input": 0,
+        "output": 0,
+        "reasoning_output": 0,
+        "total": 0,
+    }
+
+
+def unavailable_metrics() -> dict[str, int | None]:
+    return {key: None for key in empty_metrics()}
+
+
+def summarize_selected(
+    selected: list[tuple[Path, dict[str, Any]]],
+    *,
+    phase: str,
+    requested_model: str,
+    requested_effort: str,
+    since: datetime,
+    labels: dict[str, tuple[str, str, str, str]],
+    root_session_id: str,
+) -> tuple[list[dict[str, Any]], list[str], datetime | None]:
+    groups: dict[tuple[str, str, str, str, str], list[dict[str, int | None]]] = defaultdict(list)
+    warnings: list[str] = []
+    latest_observation: datetime | None = None
+    for path, metadata in selected:
+        session_id = session_identity(metadata, path.stem)
+        label = labels.get(session_id)
+        session_phase, role, _, _ = label or (
+            phase, derived_role(metadata, root_session_id), requested_model, requested_effort,
+        )
+        model = "unavailable"
+        effort = "unavailable"
+        telemetry_seen = False
+        try:
+            handle = path.open(encoding="utf-8")
+        except OSError as error:
+            warnings.append(f"could not read selected session {path.name}: {error}")
+            continue
+        with handle:
+            for line in handle:
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    warnings.append(f"ignored malformed JSONL record in {path.name}")
+                    continue
+                record_type = record.get("type")
+                payload = record.get("payload")
+                if not isinstance(payload, dict):
+                    continue
+                if record_type == "turn_context":
+                    model = payload.get("model") if isinstance(payload.get("model"), str) else "unavailable"
+                    effort = payload.get("effort") if isinstance(payload.get("effort"), str) else "unavailable"
+                    continue
+                if record_type != "event_msg" or payload.get("type") != "token_count":
+                    continue
+                timestamp = record.get("timestamp")
+                if not isinstance(timestamp, str):
+                    warnings.append(f"excluded token telemetry without a timestamp in {path.name}")
+                    continue
+                try:
+                    observed_at = parse_time(timestamp)
+                except ValueError:
+                    warnings.append(f"excluded token telemetry with an invalid timestamp in {path.name}")
+                    continue
+                if observed_at < since:
+                    continue
+                latest_observation = max(latest_observation, observed_at) if latest_observation else observed_at
+                usage = payload.get("info", {}).get("last_token_usage")
+                if not isinstance(usage, dict):
+                    warnings.append(f"missing last_token_usage in {path.name}")
+                    continue
+                values = {key: number(usage.get(key)) for key in TOKEN_KEYS}
+                reported_total = number(usage.get("total_tokens"))
+                total_consistent = (
+                    reported_total is None
+                    or values["input_tokens"] is None
+                    or values["output_tokens"] is None
+                    or reported_total == values["input_tokens"] + values["output_tokens"]
+                )
+                reasoning_consistent = (
+                    values["reasoning_output_tokens"] is None
+                    or values["output_tokens"] is None
+                    or values["reasoning_output_tokens"] <= values["output_tokens"]
+                )
+                if any(value is None for value in values.values()):
+                    warnings.append(f"incomplete token telemetry in {path.name}")
+                if not total_consistent:
+                    warnings.append(f"inconsistent total_tokens telemetry in {path.name}")
+                if not reasoning_consistent:
+                    warnings.append(f"reasoning output exceeds output telemetry in {path.name}")
+                key = (session_phase, role, session_id, model, effort)
+                groups[key].append({
+                    "input": values["input_tokens"],
+                    "cached_input": values["cached_input_tokens"],
+                    "cache_write_input": values["cache_write_input_tokens"],
+                    "output": values["output_tokens"],
+                    "reasoning_output": values["reasoning_output_tokens"] if reasoning_consistent else None,
+                    "total_consistent": int(total_consistent),
+                })
+                telemetry_seen = True
+
+        if not telemetry_seen:
+            groups.setdefault((session_phase, role, session_id, model, effort), [])
+
+    rows = []
+    for key in sorted(groups):
+        observations = groups[key]
+        metrics = unavailable_metrics()
+        metrics["response_count"] = len(observations) if observations else None
+        if observations:
+            for name in ("input", "cached_input", "cache_write_input", "output", "reasoning_output"):
+                values = [item[name] for item in observations]
+                metrics[name] = sum(value for value in values if value is not None) if all(value is not None for value in values) else None
+        if all(metrics[name] is not None for name in ("input", "cached_input", "cache_write_input")):
+            uncached = int(metrics["input"] or 0) - int(metrics["cached_input"] or 0) - int(metrics["cache_write_input"] or 0)
+            if uncached < 0:
+                warnings.append(f"inconsistent cached-input telemetry for session {key[2]}")
+            else:
+                metrics["uncached_input"] = uncached
+        total_consistent = all(item["total_consistent"] == 1 for item in observations)
+        if metrics["input"] is not None and metrics["output"] is not None and total_consistent:
+            metrics["total"] = int(metrics["input"] or 0) + int(metrics["output"] or 0)
+        elif observations and not total_consistent:
+            warnings.append(f"total unavailable for session {key[2]} because reported total_tokens is inconsistent")
+        rows.append({
+            "phase": key[0], "role": key[1], "session": key[2],
+            "requested_model": labels.get(key[2], (phase, key[1], requested_model, requested_effort))[2],
+            "requested_effort": labels.get(key[2], (phase, key[1], requested_model, requested_effort))[3],
+            "actual_model": key[3], "actual_effort": key[4], **metrics,
+        })
+    if not rows:
+        warnings.append("no usable token_count telemetry found in selected sessions")
+    if any(row["response_count"] is None for row in rows):
+        warnings.append("selected session has no usable token telemetry after the time boundary")
+    return rows, warnings, latest_observation
+
+
+def aggregate(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    metric_names = tuple(empty_metrics())
+    totals = {}
+    for name in metric_names:
+        values = [row[name] for row in rows]
+        unavailable_count = sum(value is None for value in values)
+        totals[name] = {
+            "observed_subtotal": sum(value for value in values if value is not None),
+            "complete": unavailable_count == 0,
+            "unavailable_group_count": unavailable_count,
+        }
+    return {"selected_group_count": len(rows), "metrics": totals}
+
+
+def collect(args: argparse.Namespace) -> dict[str, Any]:
+    since = parse_time(args.since)
+    selected, warnings = select_sessions(Path(args.sessions_dir), args.root_session_id, since)
+    labels = parse_labels(getattr(args, "session_labels", []))
+    rows, usage_warnings, latest_observation = summarize_selected(
+        selected, phase=args.phase, requested_model=args.requested_model, requested_effort=args.requested_effort,
+        since=since, labels=labels, root_session_id=args.root_session_id,
+    )
+    warnings.extend(usage_warnings)
+    collected_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    return {
+        "snapshot_at": collected_at,
+        "telemetry_through": (latest_observation.isoformat().replace("+00:00", "Z") if latest_observation else None),
+        "root_session_id": args.root_session_id,
+        "since": since.isoformat().replace("+00:00", "Z"),
+        "coverage": {
+            "selected_session_count": len(selected),
+            "selected_sessions": [session_identity(metadata, path.stem) for path, metadata in selected],
+            "exclusions": "Final report response and later turns are excluded because they are not observable before delivery.",
+        },
+        "groups": rows,
+        "aggregate": aggregate(rows),
+        "warnings": sorted(set(warnings)),
+    }
+
+
+def markdown(report: dict[str, Any]) -> str:
+    lines = [
+        "## Token Usage Snapshot",
+        "",
+        f"- Collected: `{report['snapshot_at']}`; telemetry through `{report['telemetry_through'] or 'unavailable'}`",
+        f"- Root session: `{report['root_session_id']}`; since `{report['since']}`",
+        f"- Coverage: {report['coverage']['selected_session_count']} linked session(s)",
+        f"- Exclusions: {report['coverage']['exclusions']}",
+        "",
+        "| Phase | Role | Session | Requested model/effort | Actual model/effort | Responses | Input | Cached input | Cache-write input | Uncached input | Output | Reasoning output | Total |",
+        "| --- | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for row in report["groups"]:
+        values = [row[key] if row[key] is not None else "unavailable" for key in (
+            "response_count", "input", "cached_input", "cache_write_input", "uncached_input", "output", "reasoning_output", "total",
+        )]
+        lines.append(
+            f"| {row['phase']} | {row['role']} | {row['session']} | {row['requested_model']}/{row['requested_effort']} | "
+            f"{row['actual_model']}/{row['actual_effort']} | " + " | ".join(map(str, values)) + " |"
+        )
+    lines.extend(["", "### Aggregate coverage", "", "| Metric | Observed subtotal | Completeness |", "| --- | ---: | --- |"])
+    for name, values in report["aggregate"]["metrics"].items():
+        completeness = "complete" if values["complete"] else f"partial; {values['unavailable_group_count']} group(s) unavailable"
+        lines.append(f"| {name} | {values['observed_subtotal']} | {completeness} |")
+    if report["warnings"]:
+        lines.extend(["", "Warnings:"])
+        lines.extend(f"- {warning}" for warning in report["warnings"])
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root-session-id", required=True)
+    parser.add_argument("--since", required=True, help="ISO-8601 UTC boundary, for example 2026-08-24T00:30:57Z")
+    parser.add_argument("--sessions-dir", default=str(Path.home() / ".codex" / "sessions"))
+    parser.add_argument("--phase", default="unavailable")
+    parser.add_argument("--requested-model", default="unavailable")
+    parser.add_argument("--requested-effort", default="unavailable")
+    parser.add_argument(
+        "--session-label", action="append", dest="session_labels", default=[],
+        metavar="SESSION=PHASE|ROLE|REQUESTED_MODEL|REQUESTED_EFFORT",
+        help="Repeat for truthful per-session workflow labels; overrides global phase and requested route.",
+    )
+    parser.add_argument("--format", choices=("markdown", "json"), default="markdown")
+    args = parser.parse_args()
+    try:
+        report = collect(args)
+    except ValueError as error:
+        parser.error(str(error))
+    if args.format == "json":
+        json.dump(report, sys.stdout, indent=2, sort_keys=True)
+        sys.stdout.write("\n")
+    else:
+        sys.stdout.write(markdown(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.codex/skills/review-gated-engineering/scripts/tests/test_summarize_token_usage.py
+++ b/.codex/skills/review-gated-engineering/scripts/tests/test_summarize_token_usage.py
@@ -4,6 +4,7 @@ import json
 import sys
 import tempfile
 import unittest
+from contextlib import contextmanager
 from pathlib import Path
 
 
@@ -36,6 +37,16 @@ def token(timestamp, input_tokens, cached, cache_write, output, reasoning, repor
             }},
         },
     }
+
+
+@contextmanager
+def fixed_integer_digit_limit():
+    original_limit = sys.get_int_max_str_digits()
+    sys.set_int_max_str_digits(sys.int_info.default_max_str_digits)
+    try:
+        yield
+    finally:
+        sys.set_int_max_str_digits(original_limit)
 
 
 def over_limit_integer_record():
@@ -317,6 +328,13 @@ class SummarizeTokenUsageTests(unittest.TestCase):
             self.assertIsNone(row["total"])
             self.assertTrue(any("missing last_token_usage" in warning for warning in report["warnings"]))
 
+    def test_fixed_integer_digit_limit_restores_original_setting(self):
+        original_limit = sys.get_int_max_str_digits()
+        with fixed_integer_digit_limit():
+            self.assertEqual(sys.get_int_max_str_digits(), sys.int_info.default_max_str_digits)
+        self.assertEqual(sys.get_int_max_str_digits(), original_limit)
+
+    @fixed_integer_digit_limit()
     def test_decoder_rejected_metadata_records_do_not_abort_indexing(self):
         with tempfile.TemporaryDirectory() as temporary:
             sessions = Path(temporary)
@@ -331,6 +349,7 @@ class SummarizeTokenUsageTests(unittest.TestCase):
             self.assertIsNone(MODULE.metadata_from(nested_metadata))
             self.assertEqual([path.name for path, _ in MODULE.session_index(sessions)], ["root.jsonl"])
 
+    @fixed_integer_digit_limit()
     def test_decoder_rejected_records_break_relay_adjacency_without_crashing(self):
         for rejected_record_type, rejected_record in (
             ("over-limit-integer", over_limit_integer_record()),

--- a/.codex/skills/review-gated-engineering/scripts/tests/test_summarize_token_usage.py
+++ b/.codex/skills/review-gated-engineering/scripts/tests/test_summarize_token_usage.py
@@ -1,6 +1,7 @@
 import argparse
 import importlib.util
 import json
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -35,6 +36,15 @@ def token(timestamp, input_tokens, cached, cache_write, output, reasoning, repor
             }},
         },
     }
+
+
+def over_limit_integer_record():
+    return '{"value":' + "9" * (sys.get_int_max_str_digits() + 1) + "}\n"
+
+
+def excessively_nested_record():
+    depth = sys.getrecursionlimit() + 10
+    return "[" * depth + "0" + "]" * depth + "\n"
 
 
 class SummarizeTokenUsageTests(unittest.TestCase):
@@ -306,6 +316,51 @@ class SummarizeTokenUsageTests(unittest.TestCase):
             self.assertIsNone(row["response_count"])
             self.assertIsNone(row["total"])
             self.assertTrue(any("missing last_token_usage" in warning for warning in report["warnings"]))
+
+    def test_decoder_rejected_metadata_records_do_not_abort_indexing(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            sessions = Path(temporary)
+            integer_metadata = sessions / "integer-metadata.jsonl"
+            nested_metadata = sessions / "nested-metadata.jsonl"
+            integer_metadata.write_text(over_limit_integer_record(), encoding="utf-8")
+            nested_metadata.write_text(excessively_nested_record(), encoding="utf-8")
+            write_session(sessions, "root.jsonl", [
+                {"type": "session_meta", "payload": {"id": "root", "session_id": "root", "timestamp": "2026-08-24T00:30:57Z"}},
+            ])
+            self.assertIsNone(MODULE.metadata_from(integer_metadata))
+            self.assertIsNone(MODULE.metadata_from(nested_metadata))
+            self.assertEqual([path.name for path, _ in MODULE.session_index(sessions)], ["root.jsonl"])
+
+    def test_decoder_rejected_records_break_relay_adjacency_without_crashing(self):
+        for rejected_record_type, rejected_record in (
+            ("over-limit-integer", over_limit_integer_record()),
+            ("excessive-nesting", excessively_nested_record()),
+        ):
+            with self.subTest(rejected_record_type=rejected_record_type):
+                with tempfile.TemporaryDirectory() as temporary:
+                    sessions = Path(temporary)
+                    path = write_session(sessions, "root.jsonl", [
+                        {"type": "session_meta", "payload": {"id": "root", "session_id": "root", "timestamp": "2026-08-24T00:30:57Z"}},
+                        token("2026-08-24T00:31:00Z", 100, 20, 0, 10, 2),
+                        {"type": "event_msg", "payload": {"type": "item_completed"}},
+                        token("2026-08-24T00:31:01Z", 100, 20, 0, 10, 2),
+                    ])
+                    path.write_text(
+                        path.read_text(encoding="utf-8")
+                        + rejected_record
+                        + json.dumps({"type": "inter_agent_communication_metadata", "payload": {"trigger_turn": False}})
+                        + "\n",
+                        encoding="utf-8",
+                    )
+                    report = MODULE.collect(argparse.Namespace(
+                        root_session_id="root", since="2026-08-24T00:30:57Z", sessions_dir=str(sessions),
+                        phase="handoff", requested_model="unavailable", requested_effort="unavailable", session_labels=[],
+                    ))
+                    row = report["groups"][0]
+                    self.assertEqual(row["response_count"], 2)
+                    self.assertEqual(row["total"], 220)
+                    self.assertTrue(any("ignored decoder-rejected JSONL" in warning for warning in report["warnings"]))
+                    self.assertFalse(any("inter-agent relay" in warning for warning in report["warnings"]))
 
     def test_boolean_token_metrics_are_unavailable_not_numeric(self):
         with tempfile.TemporaryDirectory() as temporary:

--- a/.codex/skills/review-gated-engineering/scripts/tests/test_summarize_token_usage.py
+++ b/.codex/skills/review-gated-engineering/scripts/tests/test_summarize_token_usage.py
@@ -148,6 +148,120 @@ class SummarizeTokenUsageTests(unittest.TestCase):
             self.assertTrue(any("ignored 2 post-compaction" in warning for warning in report["warnings"]))
             self.assertFalse(any("inconsistent total_tokens" in warning for warning in report["warnings"]))
 
+    def test_ignores_only_identical_snapshots_at_inter_agent_relay_boundary(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            sessions = Path(temporary)
+            write_session(sessions, "root.jsonl", [
+                {"type": "session_meta", "payload": {"id": "root", "session_id": "root", "timestamp": "2026-08-24T00:30:57Z"}},
+                token("2026-08-24T00:31:00Z", 100, 20, 0, 10, 2),
+                {"type": "event_msg", "payload": {"type": "item_completed"}},
+                token("2026-08-24T00:31:01Z", 100, 20, 0, 10, 2),
+                {"type": "inter_agent_communication_metadata", "payload": {"trigger_turn": False}},
+                {"type": "response_item", "payload": {"type": "agent_message"}},
+                token("2026-08-24T00:31:02Z", 100, 20, 0, 10, 2),
+                {"type": "event_msg", "payload": {"type": "item_completed"}},
+            ])
+            report = MODULE.collect(argparse.Namespace(
+                root_session_id="root", since="2026-08-24T00:30:57Z", sessions_dir=str(sessions),
+                phase="handoff", requested_model="unavailable", requested_effort="unavailable", session_labels=[],
+            ))
+            row = report["groups"][0]
+            self.assertEqual(row["response_count"], 2)
+            self.assertEqual(row["input"], 200)
+            self.assertEqual(row["output"], 20)
+            self.assertEqual(row["total"], 220)
+            self.assertTrue(any("ignored 1 inter-agent relay" in warning for warning in report["warnings"]))
+
+    def test_keeps_identical_snapshot_before_non_delivery_inter_agent_metadata(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            sessions = Path(temporary)
+            write_session(sessions, "root.jsonl", [
+                {"type": "session_meta", "payload": {"id": "root", "session_id": "root", "timestamp": "2026-08-24T00:30:57Z"}},
+                token("2026-08-24T00:31:00Z", 100, 20, 0, 10, 2),
+                {"type": "event_msg", "payload": {"type": "item_completed"}},
+                token("2026-08-24T00:31:01Z", 100, 20, 0, 10, 2),
+                {"type": "inter_agent_communication_metadata", "payload": {"trigger_turn": True}},
+            ])
+            report = MODULE.collect(argparse.Namespace(
+                root_session_id="root", since="2026-08-24T00:30:57Z", sessions_dir=str(sessions),
+                phase="handoff", requested_model="unavailable", requested_effort="unavailable", session_labels=[],
+            ))
+            row = report["groups"][0]
+            self.assertEqual(row["response_count"], 2)
+            self.assertEqual(row["total"], 220)
+            self.assertFalse(any("inter-agent relay" in warning for warning in report["warnings"]))
+
+    def test_keeps_incomplete_snapshot_at_delivery_boundary(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            sessions = Path(temporary)
+            incomplete = {
+                "type": "event_msg", "timestamp": "2026-08-24T00:31:00Z",
+                "payload": {"type": "token_count", "info": {"last_token_usage": {"input_tokens": 10}}},
+            }
+            replayed_incomplete = {**incomplete, "timestamp": "2026-08-24T00:31:01Z"}
+            write_session(sessions, "root.jsonl", [
+                {"type": "session_meta", "payload": {"id": "root", "session_id": "root", "timestamp": "2026-08-24T00:30:57Z"}},
+                incomplete,
+                {"type": "event_msg", "payload": {"type": "item_completed"}},
+                replayed_incomplete,
+                {"type": "inter_agent_communication_metadata", "payload": {"trigger_turn": False}},
+            ])
+            report = MODULE.collect(argparse.Namespace(
+                root_session_id="root", since="2026-08-24T00:30:57Z", sessions_dir=str(sessions),
+                phase="handoff", requested_model="unavailable", requested_effort="unavailable", session_labels=[],
+            ))
+            row = report["groups"][0]
+            self.assertEqual(row["response_count"], 2)
+            self.assertEqual(row["input"], 20)
+            self.assertIsNone(row["total"])
+            self.assertTrue(any("incomplete token telemetry" in warning for warning in report["warnings"]))
+            self.assertFalse(any("inter-agent relay" in warning for warning in report["warnings"]))
+
+    def test_malformed_record_breaks_relay_adjacency(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            sessions = Path(temporary)
+            path = write_session(sessions, "root.jsonl", [
+                {"type": "session_meta", "payload": {"id": "root", "session_id": "root", "timestamp": "2026-08-24T00:30:57Z"}},
+                token("2026-08-24T00:31:00Z", 100, 20, 0, 10, 2),
+                {"type": "event_msg", "payload": {"type": "item_completed"}},
+                token("2026-08-24T00:31:01Z", 100, 20, 0, 10, 2),
+            ])
+            path.write_text(
+                path.read_text(encoding="utf-8")
+                + "not-json\\n"
+                + json.dumps({"type": "inter_agent_communication_metadata", "payload": {"trigger_turn": False}})
+                + "\\n",
+                encoding="utf-8",
+            )
+            report = MODULE.collect(argparse.Namespace(
+                root_session_id="root", since="2026-08-24T00:30:57Z", sessions_dir=str(sessions),
+                phase="handoff", requested_model="unavailable", requested_effort="unavailable", session_labels=[],
+            ))
+            row = report["groups"][0]
+            self.assertEqual(row["response_count"], 2)
+            self.assertTrue(any("ignored malformed JSONL" in warning for warning in report["warnings"]))
+            self.assertFalse(any("inter-agent relay" in warning for warning in report["warnings"]))
+
+    def test_non_dict_record_breaks_relay_adjacency_without_crashing(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            sessions = Path(temporary)
+            write_session(sessions, "root.jsonl", [
+                {"type": "session_meta", "payload": {"id": "root", "session_id": "root", "timestamp": "2026-08-24T00:30:57Z"}},
+                token("2026-08-24T00:31:00Z", 100, 20, 0, 10, 2),
+                {"type": "event_msg", "payload": {"type": "item_completed"}},
+                token("2026-08-24T00:31:01Z", 100, 20, 0, 10, 2),
+                {"type": "inter_agent_communication_metadata", "payload": None},
+                {"type": "inter_agent_communication_metadata", "payload": {"trigger_turn": False}},
+            ])
+            report = MODULE.collect(argparse.Namespace(
+                root_session_id="root", since="2026-08-24T00:30:57Z", sessions_dir=str(sessions),
+                phase="handoff", requested_model="unavailable", requested_effort="unavailable", session_labels=[],
+            ))
+            row = report["groups"][0]
+            self.assertEqual(row["response_count"], 2)
+            self.assertEqual(row["total"], 220)
+            self.assertFalse(any("inter-agent relay" in warning for warning in report["warnings"]))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.codex/skills/review-gated-engineering/scripts/tests/test_summarize_token_usage.py
+++ b/.codex/skills/review-gated-engineering/scripts/tests/test_summarize_token_usage.py
@@ -19,7 +19,7 @@ def write_session(directory, name, records):
     return path
 
 
-def token(timestamp, input_tokens, cached, cache_write, output, reasoning):
+def token(timestamp, input_tokens, cached, cache_write, output, reasoning, reported_total=None):
     return {
         "type": "event_msg",
         "timestamp": timestamp,
@@ -31,7 +31,7 @@ def token(timestamp, input_tokens, cached, cache_write, output, reasoning):
                 "cache_write_input_tokens": cache_write,
                 "output_tokens": output,
                 "reasoning_output_tokens": reasoning,
-                "total_tokens": input_tokens + output,
+                "total_tokens": input_tokens + output if reported_total is None else reported_total,
             }},
         },
     }
@@ -126,6 +126,27 @@ class SummarizeTokenUsageTests(unittest.TestCase):
             self.assertTrue(any("inconsistent total_tokens" in warning for warning in report["warnings"]))
             self.assertTrue(any("reasoning output exceeds" in warning for warning in report["warnings"]))
             self.assertNotIn("base_instructions", MODULE.metadata_from(sessions / "root.jsonl"))
+
+    def test_ignores_repeated_post_compaction_zero_component_baselines(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            sessions = Path(temporary)
+            write_session(sessions, "root.jsonl", [
+                {"type": "session_meta", "payload": {"id": "root", "session_id": "root", "timestamp": "2026-08-24T00:30:57Z"}},
+                {"type": "compacted", "payload": {}},
+                token("2026-08-24T00:31:00Z", 0, 0, 0, 0, 0, reported_total=99),
+                {"type": "turn_context", "payload": {"model": "gpt-5.6-terra", "effort": "high"}},
+                token("2026-08-24T00:31:01Z", 0, 0, 0, 0, 0, reported_total=99),
+                token("2026-08-24T00:31:02Z", 10, 2, 0, 5, 1),
+            ])
+            report = MODULE.collect(argparse.Namespace(
+                root_session_id="root", since="2026-08-24T00:30:57Z", sessions_dir=str(sessions),
+                phase="handoff", requested_model="unavailable", requested_effort="unavailable", session_labels=[],
+            ))
+            row = report["groups"][0]
+            self.assertEqual(row["response_count"], 1)
+            self.assertEqual(row["total"], 15)
+            self.assertTrue(any("ignored 2 post-compaction" in warning for warning in report["warnings"]))
+            self.assertFalse(any("inconsistent total_tokens" in warning for warning in report["warnings"]))
 
 
 if __name__ == "__main__":

--- a/.codex/skills/review-gated-engineering/scripts/tests/test_summarize_token_usage.py
+++ b/.codex/skills/review-gated-engineering/scripts/tests/test_summarize_token_usage.py
@@ -228,9 +228,9 @@ class SummarizeTokenUsageTests(unittest.TestCase):
             ])
             path.write_text(
                 path.read_text(encoding="utf-8")
-                + "not-json\\n"
+                + "not-json\n"
                 + json.dumps({"type": "inter_agent_communication_metadata", "payload": {"trigger_turn": False}})
-                + "\\n",
+                + "\n",
                 encoding="utf-8",
             )
             report = MODULE.collect(argparse.Namespace(
@@ -261,6 +261,72 @@ class SummarizeTokenUsageTests(unittest.TestCase):
             self.assertEqual(row["response_count"], 2)
             self.assertEqual(row["total"], 220)
             self.assertFalse(any("inter-agent relay" in warning for warning in report["warnings"]))
+
+    def test_non_object_json_record_breaks_relay_adjacency(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            sessions = Path(temporary)
+            path = write_session(sessions, "root.jsonl", [
+                {"type": "session_meta", "payload": {"id": "root", "session_id": "root", "timestamp": "2026-08-24T00:30:57Z"}},
+                token("2026-08-24T00:31:00Z", 100, 20, 0, 10, 2),
+                {"type": "event_msg", "payload": {"type": "item_completed"}},
+                token("2026-08-24T00:31:01Z", 100, 20, 0, 10, 2),
+            ])
+            path.write_text(
+                path.read_text(encoding="utf-8")
+                + "[]\n"
+                + json.dumps({"type": "inter_agent_communication_metadata", "payload": {"trigger_turn": False}})
+                + "\n",
+                encoding="utf-8",
+            )
+            report = MODULE.collect(argparse.Namespace(
+                root_session_id="root", since="2026-08-24T00:30:57Z", sessions_dir=str(sessions),
+                phase="handoff", requested_model="unavailable", requested_effort="unavailable", session_labels=[],
+            ))
+            row = report["groups"][0]
+            self.assertEqual(row["response_count"], 2)
+            self.assertEqual(row["total"], 220)
+            self.assertTrue(any("ignored non-object JSONL" in warning for warning in report["warnings"]))
+            self.assertFalse(any("inter-agent relay" in warning for warning in report["warnings"]))
+
+    def test_non_object_metadata_and_info_are_ignored_without_crashing(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            sessions = Path(temporary)
+            non_object_metadata = sessions / "non-object.jsonl"
+            non_object_metadata.write_text("[]\n", encoding="utf-8")
+            self.assertIsNone(MODULE.metadata_from(non_object_metadata))
+            write_session(sessions, "root.jsonl", [
+                {"type": "session_meta", "payload": {"id": "root", "session_id": "root", "timestamp": "2026-08-24T00:30:57Z"}},
+                {"type": "event_msg", "timestamp": "2026-08-24T00:31:00Z", "payload": {"type": "token_count", "info": []}},
+            ])
+            report = MODULE.collect(argparse.Namespace(
+                root_session_id="root", since="2026-08-24T00:30:57Z", sessions_dir=str(sessions),
+                phase="handoff", requested_model="unavailable", requested_effort="unavailable", session_labels=[],
+            ))
+            row = report["groups"][0]
+            self.assertIsNone(row["response_count"])
+            self.assertIsNone(row["total"])
+            self.assertTrue(any("missing last_token_usage" in warning for warning in report["warnings"]))
+
+    def test_boolean_token_metrics_are_unavailable_not_numeric(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            sessions = Path(temporary)
+            write_session(sessions, "root.jsonl", [
+                {"type": "session_meta", "payload": {"id": "root", "session_id": "root", "timestamp": "2026-08-24T00:30:57Z"}},
+                {"type": "event_msg", "timestamp": "2026-08-24T00:31:00Z", "payload": {"type": "token_count", "info": {"last_token_usage": {
+                    "input_tokens": True, "cached_input_tokens": False, "cache_write_input_tokens": False,
+                    "output_tokens": True, "reasoning_output_tokens": False, "total_tokens": True,
+                }}}},
+            ])
+            report = MODULE.collect(argparse.Namespace(
+                root_session_id="root", since="2026-08-24T00:30:57Z", sessions_dir=str(sessions),
+                phase="handoff", requested_model="unavailable", requested_effort="unavailable", session_labels=[],
+            ))
+            row = report["groups"][0]
+            self.assertEqual(row["response_count"], 1)
+            self.assertIsNone(row["input"])
+            self.assertIsNone(row["output"])
+            self.assertIsNone(row["total"])
+            self.assertTrue(any("invalid boolean token metric" in warning for warning in report["warnings"]))
 
 
 if __name__ == "__main__":

--- a/.codex/skills/review-gated-engineering/scripts/tests/test_summarize_token_usage.py
+++ b/.codex/skills/review-gated-engineering/scripts/tests/test_summarize_token_usage.py
@@ -1,0 +1,132 @@
+import argparse
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).parents[1] / "summarize_token_usage.py"
+SPEC = importlib.util.spec_from_file_location("summarize_token_usage", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+def write_session(directory, name, records):
+    path = directory / name
+    path.write_text("\n".join(json.dumps(record) for record in records) + "\n", encoding="utf-8")
+    return path
+
+
+def token(timestamp, input_tokens, cached, cache_write, output, reasoning):
+    return {
+        "type": "event_msg",
+        "timestamp": timestamp,
+        "payload": {
+            "type": "token_count",
+            "info": {"last_token_usage": {
+                "input_tokens": input_tokens,
+                "cached_input_tokens": cached,
+                "cache_write_input_tokens": cache_write,
+                "output_tokens": output,
+                "reasoning_output_tokens": reasoning,
+                "total_tokens": input_tokens + output,
+            }},
+        },
+    }
+
+
+class SummarizeTokenUsageTests(unittest.TestCase):
+    def test_selects_linked_sessions_and_keeps_subsets_out_of_total(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            sessions = Path(temporary)
+            write_session(sessions, "root.jsonl", [
+                {"type": "session_meta", "payload": {"id": "root", "session_id": "root", "timestamp": "2026-08-24T00:30:57Z"}},
+                {"type": "turn_context", "payload": {"model": "gpt-5.6-terra", "effort": "high"}},
+                {"type": "response_item", "payload": {"content": "private prompt must not appear"}},
+                token("2026-08-24T00:30:00Z", 999, 0, 0, 1, 0),
+                token("2026-08-24T00:31:00Z", 100, 20, 5, 50, 30),
+            ])
+            write_session(sessions, "child.jsonl", [
+                {"type": "session_meta", "payload": {"id": "child", "session_id": "root", "timestamp": "2026-08-24T00:31:00Z", "source": {"subagent": {"thread_spawn": {"parent_thread_id": "root", "agent_path": "/root/implementer"}}}}},
+                {"type": "turn_context", "payload": {"model": "gpt-5.6-sol", "effort": "high"}},
+                token("2026-08-24T00:31:01Z", 40, 10, 0, 20, 5),
+            ])
+            write_session(sessions, "guardian.jsonl", [
+                {"type": "session_meta", "payload": {"id": "guardian", "session_id": "root", "timestamp": "2026-08-24T00:31:02Z", "source": {"subagent": {"other": "guardian"}}}},
+                {"type": "turn_context", "payload": {"model": "codex-auto-review", "effort": "low"}},
+            ])
+            write_session(sessions, "unrelated.jsonl", [
+                {"type": "session_meta", "payload": {"id": "other", "session_id": "root", "timestamp": "2026-08-24T00:31:00Z", "source": {"subagent": {"other": "other"}}}},
+                token("2026-08-24T00:31:01Z", 999, 0, 0, 1, 0),
+            ])
+            report = MODULE.collect(argparse.Namespace(
+                root_session_id="root", since="2026-08-24T00:30:57Z", sessions_dir=str(sessions),
+                phase="handoff", requested_model="gpt-5.6-terra", requested_effort="high",
+                session_labels=["child=review|reviewer|gpt-5.6-sol|high", "guardian=review|guardian|unavailable|unavailable"],
+            ))
+            self.assertEqual(report["coverage"]["selected_session_count"], 3)
+            self.assertEqual(len(report["groups"]), 3)
+            root = next(row for row in report["groups"] if row["session"] == "root")
+            self.assertEqual(root["role"], "coordinator")
+            self.assertEqual(root["uncached_input"], 75)
+            self.assertEqual(root["total"], 150)
+            self.assertEqual(root["reasoning_output"], 30)
+            self.assertFalse(report["aggregate"]["metrics"]["total"]["complete"])
+            self.assertEqual(report["aggregate"]["metrics"]["total"]["observed_subtotal"], 210)
+            child = next(row for row in report["groups"] if row["session"] == "child")
+            self.assertEqual(child["phase"], "review")
+            self.assertEqual(child["requested_model"], "gpt-5.6-sol")
+            guardian = next(row for row in report["groups"] if row["session"] == "guardian")
+            self.assertIsNone(guardian["response_count"])
+            self.assertIsNone(guardian["total"])
+            rendered = MODULE.markdown(report)
+            self.assertNotIn("private prompt", rendered)
+            metadata = MODULE.metadata_from(sessions / "root.jsonl")
+            self.assertNotIn("content", metadata)
+
+    def test_marks_incomplete_usage_unavailable_instead_of_zero(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            sessions = Path(temporary)
+            write_session(sessions, "root.jsonl", [
+                {"type": "session_meta", "payload": {"id": "root", "session_id": "root", "timestamp": "2026-08-24T00:30:57Z"}},
+                {"type": "event_msg", "timestamp": "2026-08-24T00:31:00Z", "payload": {"type": "token_count", "info": {"last_token_usage": {"input_tokens": 10}}}},
+            ])
+            report = MODULE.collect(argparse.Namespace(
+                root_session_id="root", since="2026-08-24T00:30:57Z", sessions_dir=str(sessions),
+                phase="handoff", requested_model="unavailable", requested_effort="unavailable",
+                session_labels=[],
+            ))
+            row = report["groups"][0]
+            self.assertEqual(row["response_count"], 1)
+            self.assertEqual(row["input"], 10)
+            self.assertIsNone(row["cached_input"])
+            self.assertIsNone(row["total"])
+            self.assertTrue(any("incomplete token telemetry" in warning for warning in report["warnings"]))
+            self.assertFalse(report["aggregate"]["metrics"]["total"]["complete"])
+
+    def test_marks_inconsistent_reported_totals_and_reasoning_unavailable(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            sessions = Path(temporary)
+            write_session(sessions, "root.jsonl", [
+                {"type": "session_meta", "payload": {"id": "root", "session_id": "root", "timestamp": "2026-08-24T00:30:57Z", "base_instructions": "private"}},
+                {"type": "event_msg", "timestamp": "2026-08-24T00:31:00Z", "payload": {"type": "token_count", "info": {"last_token_usage": {
+                    "input_tokens": 10, "cached_input_tokens": 0, "cache_write_input_tokens": 0,
+                    "output_tokens": 5, "reasoning_output_tokens": 6, "total_tokens": 12,
+                }}}},
+            ])
+            report = MODULE.collect(argparse.Namespace(
+                root_session_id="root", since="2026-08-24T00:30:57Z", sessions_dir=str(sessions),
+                phase="handoff", requested_model="unavailable", requested_effort="unavailable", session_labels=[],
+            ))
+            row = report["groups"][0]
+            self.assertIsNone(row["reasoning_output"])
+            self.assertIsNone(row["total"])
+            self.assertTrue(any("inconsistent total_tokens" in warning for warning in report["warnings"]))
+            self.assertTrue(any("reasoning output exceeds" in warning for warning in report["warnings"]))
+            self.assertNotIn("base_instructions", MODULE.metadata_from(sessions / "root.jsonl"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/release-versioning.md
+++ b/docs/release-versioning.md
@@ -21,13 +21,20 @@ Before `1.0.0`:
 
 From `1.0.0` onward, major increments represent incompatible changes, minor increments represent backwards-compatible additive changes, and patch increments represent backwards-compatible fixes.
 
+## Assessment lifecycle
+
+Before implementation, the review-gated workflow records a provisional assessment using exactly one decision: `none`, `patch`, `minor`, `major`, or `release-carrier`. At PR creation, it refreshes that assessment from the final exact base-to-head diff and current authoritative and published versions. The record names the current version, decision, proposed version when applicable, rationale/evidence, base and head SHA, assessment time, and deferred status.
+
+The primary implementation PR never changes `main/package.json` or `main/package-lock.json` merely to carry its own proposed bump. When a primary change needs a bump, first merge and verify the exact production deployment. Only then can a later direct `IMPLEMENT_TO_PR` grant authorize a dedicated version-only PR. That later PR is classified `release-carrier`; it does not recursively schedule another version bump. It still requires independent review, exact merge authorization, and post-merge verification. Publishing its semantic release remains a separate, later `RELEASE_OR_DEPLOY` authorization.
+
 ## Operator procedure
 
-1. Land the implementation with a merge commit on `main`, then wait for its **Create deployment release** workflow and Netlify production deploy to succeed.
-2. Confirm Netlify's current ready production deploy has the exact merge SHA as `commit_ref`, and confirm a non-draft `deploy-*` GitHub release targets that same SHA. Stop if production has advanced.
-3. Ensure `main/package.json` and both version fields in `main/package-lock.json` agree. Run `npm run test:release` and the normal release checks.
-4. In Actions, run **Publish semantic production release** from `main`. Provide the core version (for example `0.1.0`) and the exact 40-character merge SHA.
-5. The workflow verifies ancestry on `main`, version consistency, Netlify readiness, matching deployment provenance, existing semantic releases/tags, and monotonic version ordering before creating a release.
-6. Read back the Actions run, tag target, non-draft release, Latest status, release notes, deployment release, and Netlify deploy metadata. Record those exact links and identifiers on the tracking issue.
+1. Land the primary implementation with a merge commit on `main`, then wait for its **Create deployment release** workflow and Netlify production deploy to succeed.
+2. Confirm Netlify's current ready production deploy has the exact primary merge SHA as `commit_ref`, and confirm a non-draft `deploy-*` GitHub release targets that same SHA. Stop if production has advanced.
+3. For an assessment of `patch`, `minor`, or `major`, obtain a new direct `IMPLEMENT_TO_PR` grant and create a dedicated version-only `release-carrier` PR. Independently review it and merge only with later exact merge authorization. Do not treat the primary PR, its merge, or its deployment as authority for this carrier.
+4. Wait for the carrier merge's deployment release and Netlify production deploy. Confirm the current ready production deploy and non-draft `deploy-*` release both target that exact carrier merge SHA; stop if production has advanced.
+5. Ensure `main/package.json` and both version fields in `main/package-lock.json` agree at the carrier SHA. Run `npm run test:release` and the normal release checks.
+6. With a separate `RELEASE_OR_DEPLOY` grant, run **Publish semantic production release** from `main`. Provide the core version (for example `0.1.0`) and the exact 40-character carrier merge SHA. The workflow verifies ancestry on `main`, version consistency, Netlify readiness, matching deployment provenance, existing semantic releases/tags, and monotonic version ordering before creating a release.
+7. Read back the Actions run, tag target, non-draft release, Latest status, release notes, deployment release, and Netlify deploy metadata. Record those exact links and identifiers on the tracking issue.
 
 The workflow is idempotent only when the requested semantic tag and published non-draft release already point to the supplied commit. Tag-only, draft, duplicate, non-increasing, or different-target collisions fail for manual investigation.


### PR DESCRIPTION
## Summary
- Add provisional and exact-diff semantic version assessment with `none | patch | minor | major | release-carrier` classification.
- Require any needed bump to use a separately authorized, dedicated post-deployment version PR.
- Add a privacy-minimizing local token collector and human-gate reporting contracts with granular model and effort attribution.
- Fix relay accounting so only a complete repeated snapshot immediately followed by `inter_agent_communication_metadata` with `trigger_turn: false` is suppressed.
- Harden token parsing so non-object envelopes, boolean metrics, over-limit JSON integers, and excessively nested JSON records cannot abort or corrupt collection.
- Make the over-limit-integer regression deterministic when CPython starts with its integer-string digit limit disabled, while restoring the caller's original limit after each controlled test.
- Keep `IMPLEMENT_LOCAL` semantic assessments explicitly provisional until PR creation, while retaining binding exact-diff assessments for PR review handoffs.
- Align the PR publisher and semantic release operator documentation with the new lifecycle.

## Verification
- `python3 -m unittest discover -s .codex/skills/review-gated-engineering/scripts/tests -p 'test_*.py'` - 15 tests passed under the normal interpreter configuration.
- `PYTHONINTMAXSTRDIGITS=0 python3 -m unittest discover -s .codex/skills/review-gated-engineering/scripts/tests -p 'test_*.py'` - 15 tests passed with the limit disabled.
- `PYTHONINTMAXSTRDIGITS=640 python3 -m unittest discover -s .codex/skills/review-gated-engineering/scripts/tests -p 'test_*.py'` - 15 tests passed with a non-default positive starting limit.
- `python3 /Users/waffyahmed/.codex/skills/.system/skill-creator/scripts/quick_validate.py .codex/skills/review-gated-engineering` - skill valid.
- `npm run test:release` - 13 tests passed.
- Worktree and staged change-impact checks - only the scoped handoff-contract reference changed; no portfolio integrity validators matched.
- Portfolio preflight and pre-push hook - ESLint passed, 53 app tests passed, and the production build passed.
- `git diff --check 328c942ec44bc680a71baef55f1d651ba81d07d9...5a4fbdc774958cf23f2be3728efeab6de84d7773` - passed.

## Semantic Version Assessment
- Current version: `0.2.0`
- Published version: `v0.2.0`
- Decision: `none`
- Proposed version: none
- Basis: exact `328c942ec44bc680a71baef55f1d651ba81d07d9...5a4fbdc774958cf23f2be3728efeab6de84d7773` diff and live GitHub/package state at `2026-08-24T13:42:20Z`
- Rationale/evidence: the diff changes repo-local governance skills, documentation, a read-only local telemetry collector, and synthetic tests only. It does not change deployed portfolio behavior, release workflows, `main/package.json`, or `main/package-lock.json`.
- Deferred status: not deferred; this PR proposes no semantic bump and therefore no post-deployment version carrier.

## Notes
- The prior `CHANGES REQUIRED` verdict at `268e1d6f7b842e7a3bfaef365a16bdba29dce346` is invalidated by remediation commit `5a4fbdc774958cf23f2be3728efeab6de84d7773`.
- A fresh independent review is required at the exact new head.
- Merge, release, deployment, production mutation, and any future version-carrier PR require separate direct authorization.
