### PR TITLE
Restore WCAG AA contact placeholder contrast

### DIFF
--- a/main/e2e/production-smoke.spec.js
+++ b/main/e2e/production-smoke.spec.js
@@ -460,6 +460,26 @@ test("contact form renders without submitting to Formspree", async ({
   await page.goto("/contact/", { waitUntil: "domcontentloaded" })
   await expect(page.getByRole("heading", { name: "Contact Form" })).toBeVisible()
   await expect(page.locator("form")).toBeVisible()
+  const contactFields = page.locator(".mc-field")
+  await expect(contactFields).toHaveCount(4)
+  expect(
+    await contactFields.evaluateAll((fields) =>
+      fields.map((field) => {
+        const canvas = globalThis.document.createElement("canvas")
+        canvas.width = 1
+        canvas.height = 1
+        const context = canvas.getContext("2d")
+
+        context.fillStyle = globalThis.getComputedStyle(
+          field,
+          "::placeholder"
+        ).color
+        context.fillRect(0, 0, 1, 1)
+
+        return Array.from(context.getImageData(0, 0, 1, 1).data)
+      })
+    )
+  ).toEqual(Array.from({ length: 4 }, () => [144, 161, 185, 255]))
   expect(externalRequests.formspree).toEqual([])
   monitor.assertClean()
 })

--- a/main/src/App.test.jsx
+++ b/main/src/App.test.jsx
@@ -1235,6 +1235,7 @@ describe("App routes", () => {
     const primaryButtonRule = stylesheet.match(
       /\.mc-button-primary\s*\{[^}]+\}/
     )?.[0]
+    const fieldRule = stylesheet.match(/\.mc-field\s*\{[^}]+\}/)?.[0]
 
     expect(darkEyebrowRule).toContain("text-[#93B4FF]")
     expect(submitButton).toHaveClass("mc-button-primary")
@@ -1245,6 +1246,8 @@ describe("App routes", () => {
     expect(primaryButtonRule).toContain("disabled:text-[#334155]")
     expect(primaryButtonRule).toContain("focus:ring-[#F96302]")
     expect(primaryButtonRule).toContain("focus:ring-offset-[#0B1220]")
+    expect(fieldRule).toContain("placeholder:text-slate-400")
+    expect(fieldRule).not.toContain("placeholder:text-slate-500")
 
     expectNormalTextContrast("#93B4FF", "#0B1220")
     expectNormalTextContrast("#86EFAC", "#0B1220")
@@ -1252,6 +1255,7 @@ describe("App routes", () => {
     expectNormalTextContrast("#0B1220", "#FFB077")
     expectNormalTextContrast("#334155", "#CBD5E1")
     expectNormalTextContrast("#475569", "#F4F1EA")
+    expectNormalTextContrast("#90A1B9", "#0B1220")
   })
 
   it("redirects legacy uppercase routes to lowercase pages", async () => {

--- a/main/src/index.css
+++ b/main/src/index.css
@@ -185,7 +185,7 @@
   }
 
   .mc-field {
-    @apply w-full rounded-md border border-white/15 bg-[#0B1220]/80 px-3 py-2 text-white shadow-inner outline-hidden transition placeholder:text-slate-500 focus:border-[#F96302] focus:ring-2 focus:ring-[#F96302]/25;
+    @apply w-full rounded-md border border-white/15 bg-[#0B1220]/80 px-3 py-2 text-white shadow-inner outline-hidden transition placeholder:text-slate-400 focus:border-[#F96302] focus:ring-2 focus:ring-[#F96302]/25;
   }
 
   .mc-dark-field {


### PR DESCRIPTION
## Summary
- restore WCAG AA placeholder contrast across all four contact-form fields by replacing `slate-500` with `slate-400`
- add source-level contrast regression coverage for the shared `.mc-field` rule
- verify the rendered placeholder color for all four fields in the existing telemetry-safe, non-submitting browser test

## Verification
- `bash .codex/skills/portfolio-release-qa/scripts/portfolio_preflight.sh /Users/waffyahmed/Downloads/personalWebsite` — passed lint, 55 tests, and production build
- `node .codex/skills/portfolio-change-impact/scripts/check_change_impact.mjs --source worktree --check` — passed the GA4 event contract and frontend performance policy validators
- focused Chromium Playwright coverage — passed at 1440x1000 and 390x844 with analytics intercepted, Formspree blocked, and no real submission
- measured placeholder contrast — 6.92:1 desktop and 6.74:1 mobile, above the 4.5:1 WCAG AA normal-text threshold
- `git diff --check` — passed

## Semantic Version Assessment
- Current version: `0.2.1`
- Published version: `v0.2.1`
- Decision: `patch`
- Proposed version: `0.2.2`
- Basis: exact `de1c5a660f145d42b6a7124db147ad4dc4c470a0...a181f3f07a550f4be01ea3c8260ed133d5e5bb6f` diff and current published/version state at `2026-08-27T18:25:44Z`
- Rationale/evidence: this is a compatible accessibility defect correction with focused source and browser regression coverage
- Deferred status: this primary implementation PR does not change version files; any version-only release-carrier PR requires exact merge/deployment verification and a later direct `IMPLEMENT_TO_PR` grant

## Notes
- local browser evidence is Chromium-only; deployed production, Safari/Firefox, and assistive-technology behavior remain unverified
- telemetry-safe browser QA does not prove GA4 receipt or Formspree delivery

Refs #202
